### PR TITLE
Graphite fixes

### DIFF
--- a/OhmGraphite.Test/FormatMetricsTest.cs
+++ b/OhmGraphite.Test/FormatMetricsTest.cs
@@ -58,5 +58,26 @@ namespace OhmGraphite.Test
             string actual = writer.FormatGraphiteData(epoch, sensor);
             Assert.Equal("ohm.MY-PC.my.cpu.identifier.voltage;host=MY-PC;app=ohm;hardware=cpu;hardware_type=CPU;sensor_type=Voltage;sensor_index=1;raw_name=voltage 1.06 979344000", actual);
         }
+
+        [Fact]
+        public void FormatTagsCultureInvariant()
+        {
+            var writer = new GraphiteWriter("localhost", 2003, "MY-PC", true);
+            CultureInfo original = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                // de-DE culture will format 1.06 as 1,06 which graphite doesn't like
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+                var epoch = new DateTimeOffset(new DateTime(2001, 1, 13), TimeSpan.Zero).ToUnixTimeSeconds();
+                var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, 1);
+                string actual = writer.FormatGraphiteData(epoch, sensor);
+                Assert.Contains("1.06", actual);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = original;
+            }
+        }
     }
 }

--- a/OhmGraphite.Test/FormatMetricsTest.cs
+++ b/OhmGraphite.Test/FormatMetricsTest.cs
@@ -19,6 +19,16 @@ namespace OhmGraphite.Test
         }
 
         [Fact]
+        public void FormatGraphiteWithSpecialCharacters()
+        {
+            var writer = new GraphiteWriter("localhost", 2003, "MY-PC", false);
+            var epoch = new DateTimeOffset(new DateTime(2001, 1, 13), TimeSpan.Zero).ToUnixTimeSeconds();
+            var sensor = new ReportedValue("/nic/{my-guid}/throughput/7", "Bluetooth Network Connection 2", 1.06f, SensorType.Throughput, "cpu", HardwareType.NIC, 7);
+            string actual = writer.FormatGraphiteData(epoch, sensor);
+            Assert.Equal("ohm.MY-PC.nic.my-guid.throughput.bluetoothnetworkconnection2 1.06 979344000", actual);
+        }
+
+        [Fact]
         public void FormatCultureInvariant()
         {
             var writer = new GraphiteWriter("localhost", 2003, "MY-PC", false);

--- a/OhmGraphite/GraphiteWriter.cs
+++ b/OhmGraphite/GraphiteWriter.cs
@@ -81,7 +81,7 @@ namespace OhmGraphite
             // since some names are like "cpucore#2", turn them into
             // separate metrics by replacing "#" with "."
             string identifier = sensor.Identifier.Replace('/', '.').Substring(1);
-            identifier = identifier.Remove(identifier.LastIndexOf('.'));
+            identifier = identifier.Remove(identifier.LastIndexOf('.')).Replace("{", null).Replace("}", null);
             string name = sensor.Sensor.ToLower().Replace(" ", null).Replace('#', '.');
             return $"ohm.{host}.{identifier}.{name}";
         }

--- a/OhmGraphite/GraphiteWriter.cs
+++ b/OhmGraphite/GraphiteWriter.cs
@@ -125,7 +125,7 @@ namespace OhmGraphite
                    $"sensor_type={Enum.GetName(typeof(SensorType), data.SensorType)};" +
                    $"sensor_index={data.SensorIndex};" +
                    $"raw_name={GraphiteEscape(data.Sensor)} " +
-                   $"{data.Value} {epoch:d}";
+                   Invariant($"{data.Value} {epoch:d}");
         }
     }
 }


### PR DESCRIPTION
- Bugfix for graphite tag users in cultures that use a commas as a fractional separator.
- Bugfix for graphite network users as network ids contains guids in parentheses.