### PR TITLE
Fix prometheus and nic guids

### DIFF
--- a/OhmGraphite.Test/PrometheusTest.cs
+++ b/OhmGraphite.Test/PrometheusTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using OpenHardwareMonitor.Hardware;
 using Prometheus;
 using Xunit;
 
@@ -25,6 +27,44 @@ namespace OhmGraphite.Test
             finally
             {
                 server.Stop();
+            }
+        }
+
+        [Fact]
+        public async void PrometheusNicGuid()
+        {
+            var collector = new NicGuidSensor();
+            var prometheusCollection = new PrometheusCollection(collector, "my-pc", Metrics.DefaultRegistry);
+            var mserver = new MetricServer("localhost", 21881);
+            var server = new PrometheusServer(mserver, collector);
+            try
+            {
+                server.Start();
+                var client = new HttpClient();
+                var resp = await client.GetAsync("http://localhost:21881/metrics");
+                Assert.True(resp.IsSuccessStatusCode);
+                var content = await resp.Content.ReadAsStringAsync();
+                Assert.Contains("Bluetooth Network Connection 2", content);
+            }
+            finally
+            {
+                server.Stop();
+            }
+        }
+
+        public class NicGuidSensor : IGiveSensors
+        {
+            public IEnumerable<ReportedValue> ReadAllSensors()
+            {
+                yield return new ReportedValue("/nic/{my-guid}/throughput/7", "Bluetooth Network Connection 2", 1.06f, SensorType.Throughput, "cpu", HardwareType.NIC, 7);
+            }
+
+            public void Start()
+            {
+            }
+
+            public void Stop()
+            {
             }
         }
     }

--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -30,7 +30,11 @@ namespace OhmGraphite
             foreach (var sensor in _collector.ReadAllSensors())
             {
                 _metrics.CreateGauge(
-                        sensor.Identifier.Substring(1).Replace('/', '_'),
+                        sensor.Identifier.Substring(1)
+                            .Replace('/', '_')
+                            .Replace("{", null)
+                            .Replace("}", null)
+                            .Replace('-', '_'),
                         "Metric reported by open hardware sensor",
                         "host", "app", "hardware", "hardware_type", "sensor", "sensor_index")
                     .WithLabels(_localHost, "ohm", sensor.Hardware,


### PR DESCRIPTION
`{`, `}`, and `-` are all invalid characters for a prometheus metric so we remove them or replace them with a `_`. Closes #43