### PR TITLE
Add DNS hostname config option

### DIFF
--- a/OhmGraphite/DnsResolution.cs
+++ b/OhmGraphite/DnsResolution.cs
@@ -1,0 +1,12 @@
+﻿using System.Net;
+
+namespace OhmGraphite
+{
+    class DnsResolution : INameResolution
+    {
+        public string LookupName()
+        {
+            return Dns.GetHostName();
+        }
+    }
+}

--- a/OhmGraphite/INameResolution.cs
+++ b/OhmGraphite/INameResolution.cs
@@ -1,0 +1,7 @@
+﻿namespace OhmGraphite
+{
+    public interface INameResolution
+    {
+        string LookupName();
+    }
+}

--- a/OhmGraphite/NetBiosResolution.cs
+++ b/OhmGraphite/NetBiosResolution.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace OhmGraphite
+{
+    class NetBiosResolution : INameResolution
+    {
+        public string LookupName()
+        {
+            return Environment.MachineName;
+        }
+    }
+}

--- a/OhmGraphite/Program.cs
+++ b/OhmGraphite/Program.cs
@@ -52,6 +52,7 @@ namespace OhmGraphite
 
         private static IManage CreateManager(MetricConfig config, SensorCollector collector)
         {
+            var hostname = config.LookupName();
             double seconds = config.Interval.TotalSeconds;
             if (config.Graphite != null)
             {
@@ -59,26 +60,26 @@ namespace OhmGraphite
                     $"Graphite host: {config.Graphite.Host} port: {config.Graphite.Port} interval: {seconds} tags: {config.Graphite.Tags}");
                 var writer = new GraphiteWriter(config.Graphite.Host,
                     config.Graphite.Port,
-                    Environment.MachineName,
+                    hostname,
                     config.Graphite.Tags);
                 return new MetricTimer(config.Interval, collector, writer);
             }
             else if (config.Prometheus != null)
             {
                 Logger.Info($"Prometheus port: {config.Prometheus.Port}");
-                var prometheusCollection = new PrometheusCollection(collector, Environment.MachineName, Metrics.DefaultRegistry);
+                var prometheusCollection = new PrometheusCollection(collector, hostname, Metrics.DefaultRegistry);
                 var server = new MetricServer(config.Prometheus.Host, config.Prometheus.Port);
                 return new PrometheusServer(server, collector);
             }
             else if (config.Timescale != null)
             {
-                var writer = new TimescaleWriter(config.Timescale.Connection, config.Timescale.SetupTable, Environment.MachineName);
+                var writer = new TimescaleWriter(config.Timescale.Connection, config.Timescale.SetupTable, hostname);
                 return new MetricTimer(config.Interval, collector, writer);
             }
             else
             {
                 Logger.Info($"Influxdb address: {config.Influx.Address} db: {config.Influx.Db}");
-                var writer = new InfluxWriter(config.Influx, Environment.MachineName);
+                var writer = new InfluxWriter(config.Influx, hostname);
                 return new MetricTimer(config.Interval, collector, writer);
             }
         }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ I use this every day to create beautiful dashboards. Keep in mind, Open Hardware
 - To install the app `.\OhmGraphite.exe install`. The command will install OhmGraphite as a Windows service (so you can manage it with your favorite powershell commands or `services.msc`)
 - To start the app after installation: `.\OhmGraphite.exe start` or your favorite Windows service management tool
 
+### Hostname Resolution
+
+When OhmGraphite sends metrics to the desired sink, it includes the computers hostname for additional context to allow scenarios where one has a grafana template variable based on hostname. There two possible ways for OhmGraphite to resolved the hostname: NetBIOS (the default) and DNS. It's hard to say exactly how a machine's NetBIOS name and internet host name will differ, but to give an example, a NetBIOS name of `TINI` can have a host name of `Tini`.
+
+To switch to DNS hostname resolution, update the configuration to include `name_lookup`
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="name_lookup" value="dns" />
+  </appSettings>
+</configuration>
+```
+
 ### Graphite Configuration
 
 The config below polls our hardware every `5` seconds and sends the results to a graphite server listening on `localhost:2003`.
@@ -55,7 +70,7 @@ The config below polls our hardware every `5` seconds and sends the results to a
 </configuration>
 ```
 
-Starting with 1.1.0, Graphite supports tags (similar to InfluxDB's tags). When enabled in OhmGraphite the data format switches from `<name> <value> <timestamp>` to `<name>;tag1=a;tag2=b <value> <timestamp>`.  Since tags are such a new feature, OhmGraphite has it disabled by default to prevent cumbersome usage with Graphite 0.9 and 1.0 installations.
+Starting with Graphite v1.1.0, Graphite supports tags (similar to InfluxDB's tags). When enabled in OhmGraphite the data format switches from `<name> <value> <timestamp>` to `<name>;tag1=a;tag2=b <value> <timestamp>`.  Since tags are such a new feature, OhmGraphite has it disabled by default to prevent cumbersome usage with Graphite 0.9 and 1.0 installations.
 
 Examples of types of tags used (same for InfluxDB):
 


### PR DESCRIPTION
Ref https://github.com/nickbabcock/OhmGraphite/issues/53

Allow one to switch from sending NetBIOS machine name to metric sink and instead send the internet host name.

```xml
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
  <appSettings>
    <add key="name_lookup" value="dns" />
  </appSettings>
</configuration>
```