### PR TITLE
Only allow non-NaN and finite sensor values

### DIFF
--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -106,7 +106,19 @@ namespace OhmGraphite
             // Only report a value if the sensor was able to get a value
             // as 0 is different than "didn't read". For example, are the
             // fans really spinning at 0 RPM or was the value not read.
-            if (sensor.Value.HasValue)
+            if (!sensor.Value.HasValue)
+            {
+                Logger.Debug($"{id} did not have a value");
+            }
+            else if (float.IsNaN(sensor.Value.Value))
+            {
+                Logger.Debug($"{id} had a NaN value");
+            }
+            else if (float.IsInfinity(sensor.Value.Value))
+            {
+                Logger.Debug($"{id} had an infinite value");
+            }
+            else
             {
                 yield return new ReportedValue(id,
                     sensor.Name,
@@ -115,10 +127,6 @@ namespace OhmGraphite
                     sensor.Hardware.Name,
                     sensor.Hardware.HardwareType,
                     sensor.Index);
-            }
-            else
-            {
-                Logger.Debug($"{id} did not have a value");
             }
         }
     }


### PR DESCRIPTION
Previously, NaN and infinite values could be reported which may cause
downstream issues. For instance, Postgres / Prometheus will accept NaN
values but Grafana will error out w ith a body json marshal error. These
unexpected values should be quite rare, as out of the 25 million data
points over the past week, 14 of those over 2 seconds were reported as
NaN. It only takes a single NaN value to ruin a dashboard, so it's been
fixed, and if a NaN value were to occur again, the sensor id would be
logged under `DEBUG` before being discarded.