### PR TITLE
Group prometheus metrics

### DIFF
--- a/OhmGraphite.Test/PrometheusTest.cs
+++ b/OhmGraphite.Test/PrometheusTest.cs
@@ -12,7 +12,7 @@ namespace OhmGraphite.Test
         public async void PrometheusTestServer()
         {
             var collector = new TestSensorCreator();
-            var prometheusCollection = new PrometheusCollection(collector, "my-pc", Metrics.DefaultRegistry);
+            var prometheusCollection = new PrometheusCollection(collector, Metrics.DefaultRegistry);
             var mserver = new MetricServer("localhost", 21881);
             var server = new PrometheusServer(mserver, collector);
             try
@@ -22,7 +22,7 @@ namespace OhmGraphite.Test
                 var resp = await client.GetAsync("http://localhost:21881/metrics");
                 Assert.True(resp.IsSuccessStatusCode);
                 var content = await resp.Content.ReadAsStringAsync();
-                Assert.Contains("# HELP intelcpu_0_temperature_0 Metric reported by open hardware sensor", content);
+                Assert.Contains("# HELP ohm_temperature Metric reported by open hardware sensor", content);
             }
             finally
             {
@@ -34,7 +34,7 @@ namespace OhmGraphite.Test
         public async void PrometheusNicGuid()
         {
             var collector = new NicGuidSensor();
-            var prometheusCollection = new PrometheusCollection(collector, "my-pc", Metrics.DefaultRegistry);
+            var prometheusCollection = new PrometheusCollection(collector, Metrics.DefaultRegistry);
             var mserver = new MetricServer("localhost", 21882);
             var server = new PrometheusServer(mserver, collector);
             try

--- a/OhmGraphite.Test/PrometheusTest.cs
+++ b/OhmGraphite.Test/PrometheusTest.cs
@@ -22,7 +22,7 @@ namespace OhmGraphite.Test
                 var resp = await client.GetAsync("http://localhost:21881/metrics");
                 Assert.True(resp.IsSuccessStatusCode);
                 var content = await resp.Content.ReadAsStringAsync();
-                Assert.Contains("# HELP ohm_temperature Metric reported by open hardware sensor", content);
+                Assert.Contains("# HELP ohm_cpu_temperature_celsius Metric reported by open hardware sensor", content);
             }
             finally
             {

--- a/OhmGraphite/Program.cs
+++ b/OhmGraphite/Program.cs
@@ -67,7 +67,7 @@ namespace OhmGraphite
             else if (config.Prometheus != null)
             {
                 Logger.Info($"Prometheus port: {config.Prometheus.Port}");
-                var prometheusCollection = new PrometheusCollection(collector, hostname, Metrics.DefaultRegistry);
+                var prometheusCollection = new PrometheusCollection(collector, Metrics.DefaultRegistry);
                 var server = new MetricServer(config.Prometheus.Host, config.Prometheus.Port);
                 return new PrometheusServer(server, collector);
             }

--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -30,11 +30,7 @@ namespace OhmGraphite
             foreach (var sensor in _collector.ReadAllSensors())
             {
                 _metrics.CreateGauge(
-                        sensor.Identifier.Substring(1)
-                            .Replace('/', '_')
-                            .Replace("{", null)
-                            .Replace("}", null)
-                            .Replace('-', '_'),
+                        "ohm_" + sensor.SensorType.ToString().ToLower(),
                         "Metric reported by open hardware sensor",
                         "host", "app", "hardware", "hardware_type", "sensor", "sensor_index")
                     .WithLabels(_localHost, "ohm", sensor.Hardware,

--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -9,13 +9,11 @@ namespace OhmGraphite
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         private readonly IGiveSensors _collector;
-        private readonly string _localHost;
         private MetricFactory _metrics;
 
-        public PrometheusCollection(IGiveSensors collector, string localHost, CollectorRegistry registry)
+        public PrometheusCollection(IGiveSensors collector, CollectorRegistry registry)
         {
             _collector = collector;
-            _localHost = localHost;
             registry.AddBeforeCollectCallback(UpdateMetrics);
             _metrics = Metrics.WithCustomRegistry(registry);
         }
@@ -32,8 +30,8 @@ namespace OhmGraphite
                 _metrics.CreateGauge(
                         "ohm_" + sensor.SensorType.ToString().ToLower(),
                         "Metric reported by open hardware sensor",
-                        "host", "app", "hardware", "hardware_type", "sensor", "sensor_index")
-                    .WithLabels(_localHost, "ohm", sensor.Hardware,
+                        "hardware", "hardware_type", "sensor", "sensor_index")
+                    .WithLabels(sensor.Hardware,
                         Enum.GetName(typeof(HardwareType), sensor.HardwareType),
                         sensor.Sensor,
                         sensor.SensorIndex.ToString())

--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -23,19 +23,65 @@ namespace OhmGraphite
             Logger.LogAction("prometheus update metrics", PollSensors);
         }
 
+        private string SuffixForSensorType(SensorType type, out float multiplier)
+        {
+            multiplier = 1.0f;
+            switch (type)
+            {
+                case SensorType.Voltage: // V
+                    return "voltage_volts";
+
+                case SensorType.Clock: // MHz
+                    multiplier = 1000000;
+                    return "clock_hertz";
+
+                case SensorType.Temperature: // °C
+                    return "temperature_celsius";
+
+                case SensorType.Frequency: // Hz
+                    return "frequency_hertz";
+
+                case SensorType.Power: // W
+                    return "power_watts";
+
+                case SensorType.Data: // GB = 2^30 Bytes
+                    multiplier = 1073741824;
+                    return "bytes";
+
+                case SensorType.SmallData: // MB = 2^20 Bytes
+                    multiplier = 1048576;
+                    return "bytes";
+
+                case SensorType.Throughput: // B/s
+                    return "throughput_bytes_per_second";
+
+                case SensorType.Load: // %
+                case SensorType.Control: // %
+                case SensorType.Level: // %
+                case SensorType.Fan: // RPM
+                case SensorType.Flow: // L/h
+                case SensorType.Factor: // 1
+                default:
+                    return type.ToString().ToLower();
+            }
+        }
+
         private void PollSensors()
         {
             foreach (var sensor in _collector.ReadAllSensors())
             {
+                string suffix = SuffixForSensorType(sensor.SensorType, out float multiplier);
+
                 _metrics.CreateGauge(
-                        "ohm_" + sensor.SensorType.ToString().ToLower(),
+                        String.Format(
+                            "ohm_{0}_{1}",
+                            Enum.GetName(typeof(HardwareType), sensor.HardwareType).ToLower(),
+                            suffix
+                        ),
                         "Metric reported by open hardware sensor",
-                        "hardware", "hardware_type", "sensor", "sensor_index")
-                    .WithLabels(sensor.Hardware,
-                        Enum.GetName(typeof(HardwareType), sensor.HardwareType),
-                        sensor.Sensor,
-                        sensor.SensorIndex.ToString())
-                    .Set(sensor.Value);
+                        "hardware", "sensor")
+                    .WithLabels(sensor.Hardware, sensor.Sensor)
+                    .Set(sensor.Value * multiplier);
             }
         }
     }


### PR DESCRIPTION
These values are provided via labels and it's much easier when handling Prometheus data to filter via a label than to merge data from two different metrics.
This allows a dashboard to be generic enough to work for different machines.

Labels with data about which machine it is, and which job provided the data are added by Prometheus itself.