### PR TITLE
Sub categorize prometheus percent units

### DIFF
--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -67,9 +67,11 @@ namespace OhmGraphite
                     case SensorType.Throughput: // B/s
                         return "bytes_per_second";
                     case SensorType.Load: // %
+                        return "load_percent";
                     case SensorType.Control: // %
+                        return "control_percent";
                     case SensorType.Level: // %
-                        return "percent";
+                        return "level_percent";
                     case SensorType.Fan: // RPM
                         return "revolutions_per_minute";
                     case SensorType.Flow: // L/h


### PR DESCRIPTION
Previously all sensors that reported a percent would be lumped under a
"_percent" prefix and at best metrics would be ambiguous and at worst
metrics would conflict. For instance:

```
ohm_gpunvidia_percent
```

could refer to gpu fan control and gpu memory load. The fix is to sub
categorize the percent units into "control_percent", "load_percent", and
"level_percent"

This is a breaking change

Closes #83