### PR TITLE
Add user-configured static hostname

### DIFF
--- a/OhmGraphite.Test/ConfigTest.cs
+++ b/OhmGraphite.Test/ConfigTest.cs
@@ -85,5 +85,16 @@ namespace OhmGraphite.Test
             Assert.Equal("Host=vm-ubuntu;Username=ohm;Password=123456", results.Timescale.Connection);
             Assert.False(results.Timescale.SetupTable);
         }
+
+        [Fact]
+        public void CanParseStaticResolutionName()
+        {
+            var configMap = new ExeConfigurationFileMap { ExeConfigFilename = "assets/static-name.config" };
+            var config = ConfigurationManager.OpenMappedExeConfiguration(configMap, ConfigurationUserLevel.None);
+            var customConfig = new CustomConfig(config);
+            var results = MetricConfig.ParseAppSettings(customConfig);
+
+            Assert.Equal("my-cool-machine", results.LookupName());
+        }
     }
 }

--- a/OhmGraphite.Test/OhmGraphite.Test.csproj
+++ b/OhmGraphite.Test/OhmGraphite.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
@@ -25,6 +25,7 @@
     <None Include="..\assets\influx.config" Link="assets/influx.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\assets\default.config" Link="assets/default.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\assets\graphite.config" Link="assets/graphite.config" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\assets\static-name.config" Link="assets/static-name.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/OhmGraphite/MetricConfig.cs
+++ b/OhmGraphite/MetricConfig.cs
@@ -33,17 +33,7 @@ namespace OhmGraphite
 
             var interval = TimeSpan.FromSeconds(seconds);
 
-            var lookup = config["name_lookup"] ?? "netbios";
-            INameResolution nameLookup;
-            switch (lookup.ToLowerInvariant())
-            {
-                case "dns":
-                    nameLookup = new DnsResolution();
-                    break;
-                default:
-                    nameLookup = new NetBiosResolution();
-                    break;
-            }
+            INameResolution nameLookup = NameLookup(config["name_lookup"] ?? "netbios");
 
             var type = config["type"] ?? "graphite";
             GraphiteConfig gconfig = null;
@@ -70,6 +60,19 @@ namespace OhmGraphite
             }
 
             return new MetricConfig(interval, nameLookup, gconfig, iconfig, pconfig, timescale);
+        }
+
+        private static INameResolution NameLookup(string lookup)
+        {
+            switch (lookup.ToLowerInvariant())
+            {
+                case "dns":
+                    return new DnsResolution();
+                case "netbios":
+                    return new NetBiosResolution();
+                default:
+                    return new StaticResolution(lookup);
+            }
         }
     }
 }

--- a/OhmGraphite/StaticResolution.cs
+++ b/OhmGraphite/StaticResolution.cs
@@ -1,0 +1,11 @@
+﻿namespace OhmGraphite
+{
+    class StaticResolution : INameResolution
+    {
+        private readonly string _lookup;
+
+        public StaticResolution(string lookup) => _lookup = lookup;
+
+        public string LookupName() => _lookup;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ I use this every day to create beautiful dashboards. Keep in mind, Open Hardware
 
 ### Hostname Resolution
 
-When OhmGraphite sends metrics to the desired sink, it includes the computers hostname for additional context to allow scenarios where one has a grafana template variable based on hostname. There two possible ways for OhmGraphite to resolved the hostname: NetBIOS (the default) and DNS. It's hard to say exactly how a machine's NetBIOS name and internet host name will differ, but to give an example, a NetBIOS name of `TINI` can have a host name of `Tini`.
+When OhmGraphite sends metrics to the desired sink, it includes the computers hostname for additional context to allow scenarios where one has a grafana template variable based on hostname. There are three possible ways for OhmGraphite to resolve the hostname: NetBIOS (the default), DNS, and a static user-configured name.
 
-To switch to DNS hostname resolution, update the configuration to include `name_lookup`
+> NOTE: It's hard to say exactly how a machine's NetBIOS name and internet host name will differ, but to give an example, a NetBIOS name of `TINI` can have a host name of `Tini`.
+
+To switch to DNS hostname resolution, update the configuration to include `name_lookup`, else any other value will be assumed to be a custom static name.
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>

--- a/assets/static-name.config
+++ b/assets/static-name.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="name_lookup" value="my-cool-machine" />
+  </appSettings>
+</configuration>


### PR DESCRIPTION
Allows one to set a static hostname (instead of a net bios or dns name) like so:

```xml
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
  <appSettings>
    <add key="name_lookup" value="my-cool-machine" />
  </appSettings>
</configuration>
```

Closes https://github.com/nickbabcock/OhmGraphite/issues/92