### PR TITLE
Prometheus: transmit hardware instance for disambiguation

### DIFF
--- a/OhmGraphite.Test/FormatMetricsTest.cs
+++ b/OhmGraphite.Test/FormatMetricsTest.cs
@@ -13,7 +13,7 @@ namespace OhmGraphite.Test
         {
             var writer = new GraphiteWriter("localhost", 2003, "MY-PC", false);
             var epoch = new DateTimeOffset(new DateTime(2001, 1, 13), TimeSpan.Zero).ToUnixTimeSeconds();
-            var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, 1);
+            var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, "identifier", 1);
             string actual = writer.FormatGraphiteData(epoch, sensor);
             Assert.Equal("ohm.MY-PC.my.cpu.identifier.voltage 1.06 979344000", actual);
         }
@@ -23,7 +23,7 @@ namespace OhmGraphite.Test
         {
             var writer = new GraphiteWriter("localhost", 2003, "MY-PC", false);
             var epoch = new DateTimeOffset(new DateTime(2001, 1, 13), TimeSpan.Zero).ToUnixTimeSeconds();
-            var sensor = new ReportedValue("/nic/{my-guid}/throughput/7", "Bluetooth Network Connection 2", 1.06f, SensorType.Throughput, "cpu", HardwareType.NIC, 7);
+            var sensor = new ReportedValue("/nic/{my-guid}/throughput/7", "Bluetooth Network Connection 2", 1.06f, SensorType.Throughput, "cpu", HardwareType.NIC, "{my-guid}", 7);
             string actual = writer.FormatGraphiteData(epoch, sensor);
             Assert.Equal("ohm.MY-PC.nic.my-guid.throughput.bluetoothnetworkconnection2 1.06 979344000", actual);
         }
@@ -39,7 +39,7 @@ namespace OhmGraphite.Test
                 Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
 
                 var epoch = new DateTimeOffset(new DateTime(2001, 1, 13), TimeSpan.Zero).ToUnixTimeSeconds();
-                var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, 1);
+                var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, "identifier", 1);
                 string actual = writer.FormatGraphiteData(epoch, sensor);
                 Assert.Equal("ohm.MY-PC.my.cpu.identifier.voltage 1.06 979344000", actual);
             }
@@ -54,7 +54,7 @@ namespace OhmGraphite.Test
         {
             var writer = new GraphiteWriter("localhost", 2003, "MY-PC", true);
             var epoch = new DateTimeOffset(new DateTime(2001, 1, 13), TimeSpan.Zero).ToUnixTimeSeconds();
-            var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, 1);
+            var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, "identifier", 1);
             string actual = writer.FormatGraphiteData(epoch, sensor);
             Assert.Equal("ohm.MY-PC.my.cpu.identifier.voltage;host=MY-PC;app=ohm;hardware=cpu;hardware_type=CPU;sensor_type=Voltage;sensor_index=1;raw_name=voltage 1.06 979344000", actual);
         }
@@ -70,7 +70,7 @@ namespace OhmGraphite.Test
                 Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
 
                 var epoch = new DateTimeOffset(new DateTime(2001, 1, 13), TimeSpan.Zero).ToUnixTimeSeconds();
-                var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, 1);
+                var sensor = new ReportedValue("/my/cpu/identifier/1", "voltage", 1.06f, SensorType.Voltage, "cpu", HardwareType.CPU, "identifier", 1);
                 string actual = writer.FormatGraphiteData(epoch, sensor);
                 Assert.Contains("1.06", actual);
             }

--- a/OhmGraphite.Test/PrometheusTest.cs
+++ b/OhmGraphite.Test/PrometheusTest.cs
@@ -59,7 +59,7 @@ namespace OhmGraphite.Test
         {
             public IEnumerable<ReportedValue> ReadAllSensors()
             {
-                yield return new ReportedValue("/nic/{my-guid}/throughput/7", "Bluetooth Network Connection 2", 1.06f, SensorType.Throughput, "cpu", HardwareType.NIC, 7);
+                yield return new ReportedValue("/nic/{my-guid}/throughput/7", "Bluetooth Network Connection 2", 1.06f, SensorType.Throughput, "cpu", HardwareType.NIC, "{my-guid}", 7);
             }
 
             public void Start()

--- a/OhmGraphite.Test/TestSensorCreator.cs
+++ b/OhmGraphite.Test/TestSensorCreator.cs
@@ -7,9 +7,9 @@ namespace OhmGraphite.Test
     {
         public static IEnumerable<ReportedValue> Values()
         {
-            yield return new ReportedValue("/intelcpu/0/temperature/0", "CPU Core #1", 20, SensorType.Temperature, "Intel Core i7-6700K", HardwareType.CPU, 0);
-            yield return new ReportedValue("/intelcpu/0/temperature/1", "CPU Core #2", 15, SensorType.Temperature, "Intel Core i7-6700K", HardwareType.CPU, 1);
-            yield return new ReportedValue("/intelcpu/0/temperature/2", "CPU Core #3", 10, SensorType.Temperature, "Intel Core i7-6700K", HardwareType.CPU, 2);
+            yield return new ReportedValue("/intelcpu/0/temperature/0", "CPU Core #1", 20, SensorType.Temperature, "Intel Core i7-6700K", HardwareType.CPU, "0", 0);
+            yield return new ReportedValue("/intelcpu/0/temperature/1", "CPU Core #2", 15, SensorType.Temperature, "Intel Core i7-6700K", HardwareType.CPU, "0", 1);
+            yield return new ReportedValue("/intelcpu/0/temperature/2", "CPU Core #3", 10, SensorType.Temperature, "Intel Core i7-6700K", HardwareType.CPU, "0", 2);
         }
 
         public IEnumerable<ReportedValue> ReadAllSensors() => Values();

--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -100,8 +100,8 @@ namespace OhmGraphite
                 var (unit, value) = BaseReport(sensor);
                 var hw = Enum.GetName(typeof(HardwareType), sensor.HardwareType)?.ToLowerInvariant();
                 var name = Rx.Replace($"ohm_{hw}_{unit}", "_");
-                _metrics.CreateGauge(name, "Metric reported by open hardware sensor", "hardware", "sensor")
-                    .WithLabels(sensor.Hardware, sensor.Sensor)
+                _metrics.CreateGauge(name, "Metric reported by open hardware sensor", "hardware", "sensor", "hw_instance")
+                    .WithLabels(sensor.Hardware, sensor.Sensor, sensor.HardwareInstance)
                     .Set(value);
             }
         }

--- a/OhmGraphite/ReportedValue.cs
+++ b/OhmGraphite/ReportedValue.cs
@@ -10,6 +10,7 @@ namespace OhmGraphite
             SensorType sensorType,
             string hardware,
             HardwareType hardwareType,
+            string hwInstance,
             int sensorIndex)
         {
             Identifier = identifier;
@@ -19,6 +20,7 @@ namespace OhmGraphite
             Hardware = hardware;
             HardwareType = hardwareType;
             SensorIndex = sensorIndex;
+            HardwareInstance = hwInstance;
         }
 
         public string Identifier { get; }
@@ -28,5 +30,7 @@ namespace OhmGraphite
         public string Hardware { get; }
         public HardwareType HardwareType { get; }
         public int SensorIndex { get; }
+        public string HardwareInstance { get; }
+
     }
 }

--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -120,12 +120,17 @@ namespace OhmGraphite
             }
             else
             {
+                var hwInstance = sensor.Hardware.Identifier.ToString();
+                var ind = hwInstance.LastIndexOf('/');
+                hwInstance = hwInstance.Substring(ind + 1);
+
                 yield return new ReportedValue(id,
                     sensor.Name,
                     sensor.Value.Value,
                     sensor.SensorType,
                     sensor.Hardware.Name,
                     sensor.Hardware.HardwareType,
+                    hwInstance,
                     sensor.Index);
             }
         }


### PR DESCRIPTION
Include a "hw_instance" (hardware_instance) label to prometheus metrics. In a
multi cpu, gpu, hdd system where the name of the hardware would be the same
(ie: two graphics cards of "NVIDIA GeForce GTX 1070"), the metric values would
clobber each other. The fix is to transmit the hardware's identifier as a
metric label. These identifiers will often be an number representing the index
of hardware (eg: "0" and "1"). Nics will use their guid's. I'm hoping future
improvements could transmit the hard disk's mount point (eg: "C:\", "D:\"), as
indices can non-intuitive. Other metric reporters should not be susceptible to
this issue as the sensor's identifier is transmitted as well, so no breaking
change for them now, but if the hardware identifier notion proves fruitful
then these changes will be ported to other metric reporters.

Closes #82 
