### PR TITLE
Add translation layer for LibreHardwareMonitor enums

### DIFF
--- a/OhmGraphite.Test/FormatMetricsTest.cs
+++ b/OhmGraphite.Test/FormatMetricsTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Globalization;
 using System.Threading;
-using OpenHardwareMonitor.Hardware;
 using Xunit;
 
 namespace OhmGraphite.Test

--- a/OhmGraphite.Test/PrometheusTest.cs
+++ b/OhmGraphite.Test/PrometheusTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
-using OpenHardwareMonitor.Hardware;
 using Prometheus;
 using Xunit;
 

--- a/OhmGraphite.Test/TestSensorCreator.cs
+++ b/OhmGraphite.Test/TestSensorCreator.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using OpenHardwareMonitor.Hardware;
 
 namespace OhmGraphite.Test
 {

--- a/OhmGraphite.Test/TranslationTest.cs
+++ b/OhmGraphite.Test/TranslationTest.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Xunit;
+
+namespace OhmGraphite.Test
+{
+    public class TranslationTest
+    {
+        [Fact]
+        public void TranslateAllSensorTypes()
+        {
+            var values = Enum.GetValues(typeof(OpenHardwareMonitor.Hardware.SensorType));
+            foreach (var value in values)
+            {
+                Assert.IsType<SensorType>(((OpenHardwareMonitor.Hardware.SensorType)value).ToOwnSensor());
+            }
+        }
+
+        [Fact]
+        public void TranslateAllHardwareTypes()
+        {
+            var values = Enum.GetValues(typeof(OpenHardwareMonitor.Hardware.HardwareType));
+            foreach (var value in values)
+            {
+                Assert.IsType<HardwareType>(((OpenHardwareMonitor.Hardware.HardwareType)value).ToOwnHardware());
+            }
+        }
+    }
+}

--- a/OhmGraphite/ReportedValue.cs
+++ b/OhmGraphite/ReportedValue.cs
@@ -1,6 +1,4 @@
-﻿using OpenHardwareMonitor.Hardware;
-
-namespace OhmGraphite
+﻿namespace OhmGraphite
 {
     public class ReportedValue
     {

--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -127,9 +127,9 @@ namespace OhmGraphite
                 yield return new ReportedValue(id,
                     sensor.Name,
                     sensor.Value.Value,
-                    sensor.SensorType,
+                    sensor.SensorType.ToOwnSensor(),
                     sensor.Hardware.Name,
-                    sensor.Hardware.HardwareType,
+                    sensor.Hardware.HardwareType.ToOwnHardware(),
                     hwInstance,
                     sensor.Index);
             }

--- a/OhmGraphite/Translation.cs
+++ b/OhmGraphite/Translation.cs
@@ -1,0 +1,115 @@
+﻿using System;
+
+namespace OhmGraphite
+{
+    /// <summary>
+    /// Insulate ourselves from hardware monitor's API changes so that our metric names / values
+    /// don't unexpectedly change when a user updates OhmGraphite and their dashboard breaks
+    /// </summary>
+    public enum SensorType
+    {
+        Voltage, // V
+        Clock, // MHz
+        Temperature, // °C
+        Load, // %
+        Frequency, // Hz
+        Fan, // RPM
+        Flow, // L/h
+        Control, // %
+        Level, // %
+        Factor, // 1
+        Power, // W
+        Data, // GB = 2^30 Bytes    
+        SmallData, // MB = 2^20 Bytes
+        Throughput, // B/s
+    }
+
+    /// <summary>
+    /// Insulate ourselves from hardware monitor's API changes so that our metric names / values
+    /// don't unexpectedly change when a user updates OhmGraphite and their dashboard breaks
+    /// </summary>
+    public enum HardwareType
+    {
+        Mainboard,
+        SuperIO,
+        Aquacomputer,
+        CPU,
+        RAM,
+        GpuNvidia,
+        GpuAti,
+        TBalancer,
+        Heatmaster,
+        HDD,
+        NIC
+    }
+
+    public static class TranslationExtension {
+        public static SensorType ToOwnSensor(this OpenHardwareMonitor.Hardware.SensorType s)
+        {
+            switch (s)
+            {
+                case OpenHardwareMonitor.Hardware.SensorType.Voltage:
+                    return SensorType.Voltage;
+                case OpenHardwareMonitor.Hardware.SensorType.Clock:
+                    return SensorType.Clock;
+                case OpenHardwareMonitor.Hardware.SensorType.Temperature:
+                    return SensorType.Temperature;
+                case OpenHardwareMonitor.Hardware.SensorType.Load:
+                    return SensorType.Load; 
+                case OpenHardwareMonitor.Hardware.SensorType.Frequency:
+                    return SensorType.Frequency;
+                case OpenHardwareMonitor.Hardware.SensorType.Fan:
+                    return SensorType.Fan;  
+                case OpenHardwareMonitor.Hardware.SensorType.Flow:
+                    return SensorType.Flow;
+                case OpenHardwareMonitor.Hardware.SensorType.Control:
+                    return SensorType.Control;
+                case OpenHardwareMonitor.Hardware.SensorType.Level:
+                    return SensorType.Level;
+                case OpenHardwareMonitor.Hardware.SensorType.Factor:
+                    return SensorType.Factor;
+                case OpenHardwareMonitor.Hardware.SensorType.Power:
+                    return SensorType.Power;
+                case OpenHardwareMonitor.Hardware.SensorType.Data:
+                    return SensorType.Data;
+                case OpenHardwareMonitor.Hardware.SensorType.SmallData:
+                    return SensorType.SmallData;
+                case OpenHardwareMonitor.Hardware.SensorType.Throughput:
+                    return SensorType.Throughput;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(s), s, "unexpected hardware monitor sensor translation");
+            }
+        }
+
+        public static HardwareType ToOwnHardware(this OpenHardwareMonitor.Hardware.HardwareType s)
+        {
+            switch (s)
+            {
+                case OpenHardwareMonitor.Hardware.HardwareType.Mainboard:
+                    return HardwareType.Mainboard;
+                case OpenHardwareMonitor.Hardware.HardwareType.SuperIO:
+                    return HardwareType.SuperIO;
+                case OpenHardwareMonitor.Hardware.HardwareType.Aquacomputer:
+                    return HardwareType.Aquacomputer;
+                case OpenHardwareMonitor.Hardware.HardwareType.CPU:
+                    return HardwareType.CPU;
+                case OpenHardwareMonitor.Hardware.HardwareType.RAM:
+                    return HardwareType.RAM;
+                case OpenHardwareMonitor.Hardware.HardwareType.GpuNvidia:
+                    return HardwareType.GpuNvidia;
+                case OpenHardwareMonitor.Hardware.HardwareType.GpuAti:
+                    return HardwareType.GpuAti;
+                case OpenHardwareMonitor.Hardware.HardwareType.TBalancer:
+                    return HardwareType.TBalancer;
+                case OpenHardwareMonitor.Hardware.HardwareType.Heatmaster:
+                    return HardwareType.Heatmaster;
+                case OpenHardwareMonitor.Hardware.HardwareType.HDD:
+                    return HardwareType.HDD;
+                case OpenHardwareMonitor.Hardware.HardwareType.NIC:
+                    return HardwareType.NIC;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(s), s, "unexpected hardware monitor hardware translation");
+            }
+        }
+    }
+}


### PR DESCRIPTION
LibreHardwareMonitor enums make it into the final name for metrics. Thus
when an enum entry is renamed in an update, the metrics can be silently
updated, which can break carefully curated dashboards. The fix is to
introduce an intermediate translation layer to our own enums so that we
insulate any changes and can make a stronger guarantee to backwards
compatibility.