### PR TITLE
Bump LibreHardwareMonitor to latest

### DIFF
--- a/OhmGraphite.Test/SensorCollectorTest.cs
+++ b/OhmGraphite.Test/SensorCollectorTest.cs
@@ -1,5 +1,5 @@
 ﻿using System.Linq;
-using OpenHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 using Xunit;
 
 namespace OhmGraphite.Test
@@ -17,10 +17,10 @@ namespace OhmGraphite.Test
                 collector.Open();
                 var unused = collector.ReadAllSensors().Count();
 
-                computer.CPUEnabled = true;
-                computer.MainboardEnabled = true;
-                computer.HDDEnabled = true;
-                computer.RAMEnabled = true;
+                computer.IsCpuEnabled = true;
+                computer.IsMotherboardEnabled = true;
+                computer.IsStorageEnabled = true;
+                computer.IsMemoryEnabled = true;
 
                 var addedCount = collector.ReadAllSensors().Count();
 
@@ -30,10 +30,10 @@ namespace OhmGraphite.Test
                     return;
                 }
 
-                computer.CPUEnabled = false;
-                computer.MainboardEnabled = false;
-                computer.HDDEnabled = false;
-                computer.RAMEnabled = false;
+                computer.IsCpuEnabled = false;
+                computer.IsMotherboardEnabled = false;
+                computer.IsStorageEnabled = false;
+                computer.IsMemoryEnabled = false;
 
                 var removedCount = collector.ReadAllSensors().Count();
                 Assert.True(addedCount > removedCount, "addedCount > removedCount");

--- a/OhmGraphite.Test/TranslationTest.cs
+++ b/OhmGraphite.Test/TranslationTest.cs
@@ -8,20 +8,20 @@ namespace OhmGraphite.Test
         [Fact]
         public void TranslateAllSensorTypes()
         {
-            var values = Enum.GetValues(typeof(OpenHardwareMonitor.Hardware.SensorType));
+            var values = Enum.GetValues(typeof(LibreHardwareMonitor.Hardware.SensorType));
             foreach (var value in values)
             {
-                Assert.IsType<SensorType>(((OpenHardwareMonitor.Hardware.SensorType)value).ToOwnSensor());
+                Assert.IsType<SensorType>(((LibreHardwareMonitor.Hardware.SensorType)value).ToOwnSensor());
             }
         }
 
         [Fact]
         public void TranslateAllHardwareTypes()
         {
-            var values = Enum.GetValues(typeof(OpenHardwareMonitor.Hardware.HardwareType));
+            var values = Enum.GetValues(typeof(LibreHardwareMonitor.Hardware.HardwareType));
             foreach (var value in values)
             {
-                Assert.IsType<HardwareType>(((OpenHardwareMonitor.Hardware.HardwareType)value).ToOwnHardware());
+                Assert.IsType<HardwareType>(((LibreHardwareMonitor.Hardware.HardwareType)value).ToOwnHardware());
             }
         }
     }

--- a/OhmGraphite.sln
+++ b/OhmGraphite.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29503.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OhmGraphite", "OhmGraphite\OhmGraphite.csproj", "{329E2785-6E88-449F-A641-6ACCBFF943CA}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenHardwareMonitorLib", "LibreHardwareMonitor\OpenHardwareMonitorLib.csproj", "{B0397530-545A-471D-BB74-027AE456DF1A}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OhmGraphite.Test", "OhmGraphite.Test\OhmGraphite.Test.csproj", "{E6C3F138-BED7-4350-B1F0-95AE87640CFB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibreHardwareMonitorLib", "LibreHardwareMonitor\LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj", "{EBF013C2-0600-4439-8D16-1925A015D15B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,14 +19,14 @@ Global
 		{329E2785-6E88-449F-A641-6ACCBFF943CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{329E2785-6E88-449F-A641-6ACCBFF943CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{329E2785-6E88-449F-A641-6ACCBFF943CA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B0397530-545A-471D-BB74-027AE456DF1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B0397530-545A-471D-BB74-027AE456DF1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B0397530-545A-471D-BB74-027AE456DF1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B0397530-545A-471D-BB74-027AE456DF1A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E6C3F138-BED7-4350-B1F0-95AE87640CFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E6C3F138-BED7-4350-B1F0-95AE87640CFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E6C3F138-BED7-4350-B1F0-95AE87640CFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6C3F138-BED7-4350-B1F0-95AE87640CFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBF013C2-0600-4439-8D16-1925A015D15B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBF013C2-0600-4439-8D16-1925A015D15B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBF013C2-0600-4439-8D16-1925A015D15B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBF013C2-0600-4439-8D16-1925A015D15B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OhmGraphite/GraphiteWriter.cs
+++ b/OhmGraphite/GraphiteWriter.cs
@@ -5,7 +5,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using NLog;
-using OpenHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 using static System.FormattableString;
 
 namespace OhmGraphite

--- a/OhmGraphite/InfluxWriter.cs
+++ b/OhmGraphite/InfluxWriter.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using InfluxDB.LineProtocol.Client;
 using InfluxDB.LineProtocol.Payload;
 using NLog;
-using OpenHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 
 namespace OhmGraphite
 {

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -38,12 +38,9 @@
     <PackageReference Include="InfluxDB.LineProtocol" Version="1.1.0" />
     <PackageReference Include="MSBuildTasks" Version="1.5.0.235" />
   </ItemGroup>
+
   <ItemGroup>
-    <!-- May need to add in "AdditionalProperties="TargetFramework=net461"" or something
-         like that in the future as errors arising from Hidl library about not being
-         compatible with netstandard 2.0 is annoying (but doesn't break the build).
-         For inspiration, see: https://stackoverflow.com/a/48530388/433785 -->
-    <ProjectReference Include="..\LibreHardwareMonitor\OpenHardwareMonitorLib.csproj" />
+    <ProjectReference Include="..\LibreHardwareMonitor\LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Configuration" />

--- a/OhmGraphite/Program.cs
+++ b/OhmGraphite/Program.cs
@@ -1,5 +1,5 @@
 ﻿using NLog;
-using OpenHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 using Prometheus;
 using Topshelf;
 
@@ -19,15 +19,14 @@ namespace OhmGraphite
                     // to send to graphite
                     var computer = new Computer
                     {
-                        GPUEnabled = true,
-                        MainboardEnabled = true,
-                        CPUEnabled = true,
-                        RAMEnabled = true,
-                        FanControllerEnabled = true,
-                        HDDEnabled = true,
-                        NICEnabled = true
+                        IsGpuEnabled = true,
+                        IsMotherboardEnabled = true,
+                        IsCpuEnabled = true,
+                        IsMemoryEnabled = true,
+                        IsNetworkEnabled = true,
+                        IsStorageEnabled = true,
+                        IsControllerEnabled = true
                     };
-
                     var collector = new SensorCollector(computer);
 
                     // We need to know where the graphite server lives and how often

--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 using NLog;
-using OpenHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 using Prometheus;
 
 namespace OhmGraphite

--- a/OhmGraphite/ReportedValue.cs
+++ b/OhmGraphite/ReportedValue.cs
@@ -1,4 +1,4 @@
-﻿namespace OhmGraphite
+namespace OhmGraphite
 {
     public class ReportedValue
     {

--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
-using OpenHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 
 namespace OhmGraphite
 {

--- a/OhmGraphite/TimescaleWriter.cs
+++ b/OhmGraphite/TimescaleWriter.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using NLog;
 using Npgsql;
 using NpgsqlTypes;
-using OpenHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 
 namespace OhmGraphite
 {

--- a/OhmGraphite/Translation.cs
+++ b/OhmGraphite/Translation.cs
@@ -44,68 +44,68 @@ namespace OhmGraphite
     }
 
     public static class TranslationExtension {
-        public static SensorType ToOwnSensor(this OpenHardwareMonitor.Hardware.SensorType s)
+        public static SensorType ToOwnSensor(this LibreHardwareMonitor.Hardware.SensorType s)
         {
             switch (s)
             {
-                case OpenHardwareMonitor.Hardware.SensorType.Voltage:
+                case LibreHardwareMonitor.Hardware.SensorType.Voltage:
                     return SensorType.Voltage;
-                case OpenHardwareMonitor.Hardware.SensorType.Clock:
+                case LibreHardwareMonitor.Hardware.SensorType.Clock:
                     return SensorType.Clock;
-                case OpenHardwareMonitor.Hardware.SensorType.Temperature:
+                case LibreHardwareMonitor.Hardware.SensorType.Temperature:
                     return SensorType.Temperature;
-                case OpenHardwareMonitor.Hardware.SensorType.Load:
+                case LibreHardwareMonitor.Hardware.SensorType.Load:
                     return SensorType.Load; 
-                case OpenHardwareMonitor.Hardware.SensorType.Frequency:
+                case LibreHardwareMonitor.Hardware.SensorType.Frequency:
                     return SensorType.Frequency;
-                case OpenHardwareMonitor.Hardware.SensorType.Fan:
+                case LibreHardwareMonitor.Hardware.SensorType.Fan:
                     return SensorType.Fan;  
-                case OpenHardwareMonitor.Hardware.SensorType.Flow:
+                case LibreHardwareMonitor.Hardware.SensorType.Flow:
                     return SensorType.Flow;
-                case OpenHardwareMonitor.Hardware.SensorType.Control:
+                case LibreHardwareMonitor.Hardware.SensorType.Control:
                     return SensorType.Control;
-                case OpenHardwareMonitor.Hardware.SensorType.Level:
+                case LibreHardwareMonitor.Hardware.SensorType.Level:
                     return SensorType.Level;
-                case OpenHardwareMonitor.Hardware.SensorType.Factor:
+                case LibreHardwareMonitor.Hardware.SensorType.Factor:
                     return SensorType.Factor;
-                case OpenHardwareMonitor.Hardware.SensorType.Power:
+                case LibreHardwareMonitor.Hardware.SensorType.Power:
                     return SensorType.Power;
-                case OpenHardwareMonitor.Hardware.SensorType.Data:
+                case LibreHardwareMonitor.Hardware.SensorType.Data:
                     return SensorType.Data;
-                case OpenHardwareMonitor.Hardware.SensorType.SmallData:
+                case LibreHardwareMonitor.Hardware.SensorType.SmallData:
                     return SensorType.SmallData;
-                case OpenHardwareMonitor.Hardware.SensorType.Throughput:
+                case LibreHardwareMonitor.Hardware.SensorType.Throughput:
                     return SensorType.Throughput;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(s), s, "unexpected hardware monitor sensor translation");
             }
         }
 
-        public static HardwareType ToOwnHardware(this OpenHardwareMonitor.Hardware.HardwareType s)
+        public static HardwareType ToOwnHardware(this LibreHardwareMonitor.Hardware.HardwareType s)
         {
             switch (s)
             {
-                case OpenHardwareMonitor.Hardware.HardwareType.Mainboard:
+                case LibreHardwareMonitor.Hardware.HardwareType.Motherboard:
                     return HardwareType.Mainboard;
-                case OpenHardwareMonitor.Hardware.HardwareType.SuperIO:
+                case LibreHardwareMonitor.Hardware.HardwareType.SuperIO:
                     return HardwareType.SuperIO;
-                case OpenHardwareMonitor.Hardware.HardwareType.Aquacomputer:
+                case LibreHardwareMonitor.Hardware.HardwareType.AquaComputer:
                     return HardwareType.Aquacomputer;
-                case OpenHardwareMonitor.Hardware.HardwareType.CPU:
+                case LibreHardwareMonitor.Hardware.HardwareType.Cpu:
                     return HardwareType.CPU;
-                case OpenHardwareMonitor.Hardware.HardwareType.RAM:
+                case LibreHardwareMonitor.Hardware.HardwareType.Memory:
                     return HardwareType.RAM;
-                case OpenHardwareMonitor.Hardware.HardwareType.GpuNvidia:
+                case LibreHardwareMonitor.Hardware.HardwareType.GpuNvidia:
                     return HardwareType.GpuNvidia;
-                case OpenHardwareMonitor.Hardware.HardwareType.GpuAti:
+                case LibreHardwareMonitor.Hardware.HardwareType.GpuAmd:
                     return HardwareType.GpuAti;
-                case OpenHardwareMonitor.Hardware.HardwareType.TBalancer:
+                case LibreHardwareMonitor.Hardware.HardwareType.TBalancer:
                     return HardwareType.TBalancer;
-                case OpenHardwareMonitor.Hardware.HardwareType.Heatmaster:
+                case LibreHardwareMonitor.Hardware.HardwareType.Heatmaster:
                     return HardwareType.Heatmaster;
-                case OpenHardwareMonitor.Hardware.HardwareType.HDD:
+                case LibreHardwareMonitor.Hardware.HardwareType.Storage:
                     return HardwareType.HDD;
-                case OpenHardwareMonitor.Hardware.HardwareType.NIC:
+                case LibreHardwareMonitor.Hardware.HardwareType.Network:
                     return HardwareType.NIC;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(s), s, "unexpected hardware monitor hardware translation");

--- a/OhmGraphite/UpdateVisitor.cs
+++ b/OhmGraphite/UpdateVisitor.cs
@@ -1,4 +1,4 @@
-﻿using OpenHardwareMonitor.Hardware;
+﻿using LibreHardwareMonitor.Hardware;
 
 namespace OhmGraphite
 {


### PR DESCRIPTION
Big update to the underlying LibreHardwareMonitor library, I've tried to
ensure that backwards compatibility is maintained in respect to the
metric names that are generated; however, there some breakages may slip
through. For instance, I believe that the CPU DRAM power sensor for
intel chips have been relabed to "CPU Memory", so one should double
check and adjust their dashboards as needed.

Other changes to LibreHardwareMonitor:

- Add SoC voltage for Ryzen 2
- Add support for AMD / ATI rx5700 GPUs
- Fix Ryzen temperature offsets
- Add motherboard: B350 Gaming Plus
- Add motherboard: X470 AORUS GAMING 7 WIFI-CF
- Add motherboard: ITE IT8792E
- Add liquid + plx temperatures and power usage for AMD / ATI GPUs.
- Bugfix for Asrock Pro / Steel Legend B450 motherboards
- Add detection for additional Intel architectures:
  - Goldmont
  - Goldmont Plus
  - Cannon Lake
  - Ice Lake
  - Tiger Lake
  - Tremont
- Add basic support for Aquacomputer's MPS (USB high flow)
- Discard out of range temperatures for NVMe drives (-1000, 1000)

Closes #108 #110

Waiting for https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/192 before merging