### PR TITLE
Alias a sensor name by sensor id

### DIFF
--- a/OhmGraphite.Test/BlankConfig.cs
+++ b/OhmGraphite.Test/BlankConfig.cs
@@ -1,0 +1,9 @@
+﻿namespace OhmGraphite.Test
+{
+    class BlankConfig : IAppConfig
+    {
+        public string this[string name] => null;
+
+        public string[] GetKeys() => new string[] { };
+    }
+}

--- a/OhmGraphite.Test/ConfigTest.cs
+++ b/OhmGraphite.Test/ConfigTest.cs
@@ -96,5 +96,20 @@ namespace OhmGraphite.Test
 
             Assert.Equal("my-cool-machine", results.LookupName());
         }
+
+        [Fact]
+        public void CanParseSensorAlias()
+        {
+            var configMap = new ExeConfigurationFileMap { ExeConfigFilename = "assets/rename.config" };
+            var config = ConfigurationManager.OpenMappedExeConfiguration(configMap, ConfigurationUserLevel.None);
+            var customConfig = new CustomConfig(config);
+            var results = MetricConfig.ParseAppSettings(customConfig);
+
+            Assert.True(results.TryGetAlias("/amdcpu/0/load/1", out string alias));
+            Assert.Equal("CPU Core 0 T0", alias);
+            Assert.True(results.TryGetAlias("/amdcpu/0/load/2", out alias));
+            Assert.Equal("CPU Core 0 T1", alias);
+            Assert.False(results.TryGetAlias("/amdcpu/0/load/3", out alias));
+        }
     }
 }

--- a/OhmGraphite.Test/CustomConfig.cs
+++ b/OhmGraphite.Test/CustomConfig.cs
@@ -12,5 +12,6 @@ namespace OhmGraphite.Test
         }
 
         public string this[string name] => _config.AppSettings.Settings[name]?.Value;
+        public string[] GetKeys() => _config.AppSettings.Settings.AllKeys;
     }
 }

--- a/OhmGraphite.Test/OhmGraphite.Test.csproj
+++ b/OhmGraphite.Test/OhmGraphite.Test.csproj
@@ -26,6 +26,7 @@
     <None Include="..\assets\default.config" Link="assets/default.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\assets\graphite.config" Link="assets/graphite.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\assets\static-name.config" Link="assets/static-name.config" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\assets\rename.config" Link="assets/rename.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/OhmGraphite.Test/SensorCollectorTest.cs
+++ b/OhmGraphite.Test/SensorCollectorTest.cs
@@ -10,7 +10,7 @@ namespace OhmGraphite.Test
         public void SensorsAddedWhenHardwareAdded()
         {
             var computer = new Computer();
-            var collector = new SensorCollector(computer);
+            var collector = new SensorCollector(computer, MetricConfig.ParseAppSettings(new BlankConfig()));
 
             try
             {

--- a/OhmGraphite/AppConfigManager.cs
+++ b/OhmGraphite/AppConfigManager.cs
@@ -5,5 +5,7 @@ namespace OhmGraphite
     class AppConfigManager : IAppConfig
     {
         public string this[string name] => ConfigurationManager.AppSettings[name];
+
+        public string[] GetKeys() => ConfigurationManager.AppSettings.AllKeys;
     }
 }

--- a/OhmGraphite/IAppConfig.cs
+++ b/OhmGraphite/IAppConfig.cs
@@ -3,5 +3,6 @@
     public interface IAppConfig
     {
         string this[string name] { get; }
+        string[] GetKeys();
     }
 }

--- a/OhmGraphite/Program.cs
+++ b/OhmGraphite/Program.cs
@@ -27,13 +27,12 @@ namespace OhmGraphite
                         IsStorageEnabled = true,
                         IsControllerEnabled = true
                     };
-                    var collector = new SensorCollector(computer);
 
                     // We need to know where the graphite server lives and how often
                     // to poll the hardware
                     var config = Logger.LogFunction("parse config", () => MetricConfig.ParseAppSettings(new AppConfigManager()));
+                    var collector = new SensorCollector(computer, config);
                     var metricsManager = CreateManager(config, collector);
-
                     s.ConstructUsing(name => metricsManager);
                     s.WhenStarted(tc => tc.Start());
                     s.WhenStopped(tc => tc.Dispose());

--- a/assets/rename.config
+++ b/assets/rename.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="host" value="myhost" />
+    <add key="port" value="2004" />
+    <add key="interval" value="6" />
+    <add key="tags" value="true" />
+
+    <add key="/amdcpu/0/load/1/name" value="CPU Core 0 T0" />
+    <add key="/amdcpu/0/load/2/name" value="CPU Core 0 T1" />
+  </appSettings>
+</configuration>


### PR DESCRIPTION
LibreHardwareMonitor allows one to customize the name for a given
sensor.

![image](https://user-images.githubusercontent.com/2106129/79525786-58cbff00-8029-11ea-8e5f-5d12546990ca.png)

This customized name is stored in `LibreHardwareMonitor.config`
as a combination of sensor id and `/name` suffix:

```xml
<add key="/<sensor-id>/name" value="<alias>" />
```

Like the following:

```xml
<add key="/lpc/nct6792d/fan/1/name" value="superfan" />
```

The XML format of the config is the exact same as OhmGraphite's, so this commit
allows one to copy and paste an exact alias line from LibreHardwareMonitor's
config into OhmGraphite's config as shown below.

```xml
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
  <appSettings>
    <add key="type" value="prometheus" />
    <add key="prometheus_port" value="4445" />
    <add key="prometheus_host" value="*" />

    <add key="/lpc/nct6792d/fan/1/name" value="superfan" />
  </appSettings>
</configuration>
```

The recommendation for users that want to alias is to prepare their
aliasing in LibreHardwareMonitor as that is the most surefire way to
generate the alias config (nothing beats copy + paste). For those not
interested in using LibreHardwareMonitor for creating aliases, InfluxDB
and Postgres / TimescaleDB users can craft it by hand by examining their
data sources as the sensor id is stored in those backends (Prometheus
collector omits sensor id due to avoid high cardinality and Graphite
translates it by removing inappropriate characters).

Aliasing sensors will allow users that additional ways to craft
dashboards with desired names as some backends make it difficult to
create aliases (eg: with postgres a `view` could be used but creating an
alias on a single metric in influxdb is more difficult).

End result:

![image](https://user-images.githubusercontent.com/2106129/79525800-62556700-8029-11ea-9e3b-5a4ed670945e.png)

Closes #130