### PR TITLE
Include sensor name when logging added sensor

### DIFF
--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -89,8 +89,9 @@ namespace OhmGraphite
 
         private void SensorAdded(ISensor sensor)
         {
-            Logger.Debug(!_ids.TryAdd(sensor.Identifier, sensor) ?
-                    "Sensor previously added: {0}" : "Sensor added: {0}", sensor.Identifier);
+            var added = _ids.TryAdd(sensor.Identifier, sensor);
+            var msg = added ? "Sensor added: {0} \"{1}\"" : "Sensor previously added: {0} \"{1}\"";
+            Logger.Info(msg, sensor.Identifier, sensor.Name);
         }
 
         private void SensorRemoved(ISensor sensor)


### PR DESCRIPTION
With sensor name aliasing on master there should be a self contained way
to determine the sensor id for a given name, as relying on users running
LibreHardwareMonitor would be too inconvenient.

This commit modifies the "Sensor added" log line, which already prints
out the sensor's id to include the sensor name.

Now if someone wants to update the `Fan #2` sensor they can open the
OhmGraphite.log and search for `Fan #2` and see the following line:

```
Sensor added: /lpc/nct6792d/fan/1 "Fan #2"
```

Then the this line can be used to add the alias line to
`OhmGraphite.exe.config`

```xml
<add key="/lpc/nct6792d/fan/1/name" value="superfan" />
```