### PR TITLE
Add NVMe SMART Sensors

### DIFF
--- a/OhmGraphite/OhmNvme.cs
+++ b/OhmGraphite/OhmNvme.cs
@@ -1,0 +1,66 @@
+﻿using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware.Storage;
+
+namespace OhmGraphite
+{
+    // LibreHardwareMonitor doesn't expose all the SMART attributes on a generic NVMe drive
+    // so we create our own pseudo-hardware class that exposes some important factors
+    internal class OhmNvme
+    {
+        private readonly NVMeGeneric _nvme;
+
+        public OhmNvme(NVMeGeneric nvme)
+        {
+            _nvme = nvme;
+            var factor = LibreHardwareMonitor.Hardware.SensorType.Factor.ToString().ToLowerInvariant();
+            ErrorInfoLogEntryCount = new OhmSensor
+            {
+                Identifier = new Identifier(nvme.Identifier, factor, "error_info_log_entries"),
+                Name = "Error Info Log Entries",
+                Hardware = nvme,
+                SensorType = LibreHardwareMonitor.Hardware.SensorType.Factor,
+            };
+
+            MediaErrors = new OhmSensor
+            {
+                Identifier = new Identifier(nvme.Identifier, factor, "media_errors"),
+                Name = "Media Errors",
+                Hardware = nvme,
+                SensorType = LibreHardwareMonitor.Hardware.SensorType.Factor,
+            };
+
+            PowerCycles = new OhmSensor
+            {
+                Identifier = new Identifier(nvme.Identifier, factor, "power_cycles"),
+                Name = "Power Cycles",
+                Hardware = nvme,
+                SensorType = LibreHardwareMonitor.Hardware.SensorType.Factor,
+            };
+
+            UnsafeShutdowns = new OhmSensor
+            {
+                Identifier = new Identifier(nvme.Identifier, factor, "unsafe_shutdowns"),
+                Name = "Unsafe Shutdowns",
+                Hardware = nvme,
+                SensorType = LibreHardwareMonitor.Hardware.SensorType.Factor,
+            };
+        }
+
+        public OhmSensor UnsafeShutdowns { get; }
+
+        public OhmSensor PowerCycles { get; }
+
+        public OhmSensor MediaErrors { get; }
+
+        public OhmSensor ErrorInfoLogEntryCount { get; }
+
+        public void Update()
+        {
+            var health = _nvme.Smart.GetHealthInfo();
+            ErrorInfoLogEntryCount.Value = health.ErrorInfoLogEntryCount;
+            MediaErrors.Value = health.MediaErrors;
+            PowerCycles.Value = health.PowerCycle;
+            UnsafeShutdowns.Value = health.UnsafeShutdowns;
+        }
+    }
+}

--- a/OhmGraphite/OhmSensor.cs
+++ b/OhmGraphite/OhmSensor.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LibreHardwareMonitor.Hardware;
+
+namespace OhmGraphite
+{
+    class OhmSensor : ISensor
+    {
+        public void Accept(IVisitor visitor)
+        {
+        }
+
+        public void Traverse(IVisitor visitor)
+        {
+        }
+
+        public IControl Control => null;
+        public IHardware Hardware { get; set; }
+        public Identifier Identifier { get; set; }
+        public int Index => 0;
+        public bool IsDefaultHidden => false;
+        public float? Max => null;
+        public float? Min => null;
+        public string Name { get; set; }
+        public IReadOnlyList<IParameter> Parameters => new List<IParameter>();
+        public LibreHardwareMonitor.Hardware.SensorType SensorType { get; set; }
+        public float? Value { get; set; }
+        public IEnumerable<SensorValue> Values => new List<SensorValue>();
+        public TimeSpan ValuesTimeWindow { get; set; }
+
+        public void ResetMin()
+        {
+        }
+
+        public void ResetMax()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Since LibreHardwareMonitor doesn't expose them as sensors, we expose our
own sensors. This doesn't cover all of the attributes exposed by smart (like
power on hours, which doesn't have a corresponding sensor type as of now),
but I figure something is better than nothing (and we can expose more in the
future).

![image](https://user-images.githubusercontent.com/2106129/79640656-4f8d8000-8158-11ea-841d-91bb784e812b.png)

Closes #119 