### PR TITLE
Hide sensors from export with configuration

### DIFF
--- a/OhmGraphite.Test/ConfigTest.cs
+++ b/OhmGraphite.Test/ConfigTest.cs
@@ -111,5 +111,18 @@ namespace OhmGraphite.Test
             Assert.Equal("CPU Core 0 T1", alias);
             Assert.False(results.TryGetAlias("/amdcpu/0/load/3", out alias));
         }
+
+        [Fact]
+        public void CanParseHiddenSensors()
+        {
+            var configMap = new ExeConfigurationFileMap { ExeConfigFilename = "assets/hidden-sensors.config" };
+            var config = ConfigurationManager.OpenMappedExeConfiguration(configMap, ConfigurationUserLevel.None);
+            var customConfig = new CustomConfig(config);
+            var results = MetricConfig.ParseAppSettings(customConfig);
+
+            Assert.True(results.IsHidden("/amdcpu/0/load/1"));
+            Assert.True(results.IsHidden("/amdcpu/0/load/2"));
+            Assert.False(results.IsHidden("/amdcpu/0/load/3"));
+        }
     }
 }

--- a/OhmGraphite.Test/OhmGraphite.Test.csproj
+++ b/OhmGraphite.Test/OhmGraphite.Test.csproj
@@ -27,6 +27,7 @@
     <None Include="..\assets\graphite.config" Link="assets/graphite.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\assets\static-name.config" Link="assets/static-name.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\assets\rename.config" Link="assets/rename.config" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\assets\hidden-sensors.config" Link="assets/hidden-sensors.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -152,7 +152,7 @@ namespace OhmGraphite
             {
                 Logger.Debug($"{id} had an infinite value");
             }
-            else
+            else if (!_config.IsHidden(sensor.Identifier.ToString()))
             {
                 var hwInstance = sensor.Hardware.Identifier.ToString();
                 var ind = hwInstance.LastIndexOf('/');

--- a/README.md
+++ b/README.md
@@ -211,6 +211,16 @@ It is possible that the sensor names exposed through OhmGraphite are not descrip
     <add key="/lpc/nct6792d/fan/1/name" value="CPU Fan" />
 ```
 
+### Hiding Sensors
+
+There may be a sensor that is faulty on a given machine. Maybe it reports negative temperatures. This can throw off monitoring software or make it harder to maintain with all the special cases. OhmGraphite allows one to exclude a sensor from being exported by modifying the OhmGraphite config and adding the `/hidden` suffix to the sensor id like so:
+
+```xml
+<add key="/lpc/nct6792d/temperature/1/hidden" />
+```
+
+### Determine Sensor Id
+
 There are several ways to determine the sensor id of a metric:
 
 - Postgres / Timescale and Influxdb users can examine their data store for the sensor id

--- a/assets/hidden-sensors.config
+++ b/assets/hidden-sensors.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="host" value="myhost" />
+    <add key="port" value="2004" />
+    <add key="interval" value="6" />
+    <add key="tags" value="true" />
+
+    <add key="/amdcpu/0/load/1/hidden" />
+    <add key="/amdcpu/0/load/2/hidden" />
+  </appSettings>
+</configuration>


### PR DESCRIPTION
There may be a sensor that is faulty on a given machine. Maybe it reports negative temperatures. This can throw off monitoring software or make it harder to maintain with all the special cases. OhmGraphite allows one to exclude a sensor from being exported by modifying the OhmGraphite config and adding the `/hidden` suffix to the sensor id like so:

```xml
<add key="/lpc/nct6792d/temperature/1/hidden" />
```

Closes #140