### PR TITLE
Bump libre to latest

### DIFF
--- a/OhmGraphite/Translation.cs
+++ b/OhmGraphite/Translation.cs
@@ -32,14 +32,11 @@ namespace OhmGraphite
     {
         Mainboard,
         SuperIO,
-        Aquacomputer,
-        AeroCool,
         CPU,
         RAM,
         GpuNvidia,
         GpuAti,
-        TBalancer,
-        Heatmaster,
+        Cooler,
         HDD,
         NIC
     }
@@ -90,10 +87,6 @@ namespace OhmGraphite
                     return HardwareType.Mainboard;
                 case LibreHardwareMonitor.Hardware.HardwareType.SuperIO:
                     return HardwareType.SuperIO;
-                case LibreHardwareMonitor.Hardware.HardwareType.AquaComputer:
-                    return HardwareType.Aquacomputer;
-                case LibreHardwareMonitor.Hardware.HardwareType.AeroCool:
-                    return HardwareType.AeroCool;
                 case LibreHardwareMonitor.Hardware.HardwareType.Cpu:
                     return HardwareType.CPU;
                 case LibreHardwareMonitor.Hardware.HardwareType.Memory:
@@ -102,10 +95,8 @@ namespace OhmGraphite
                     return HardwareType.GpuNvidia;
                 case LibreHardwareMonitor.Hardware.HardwareType.GpuAmd:
                     return HardwareType.GpuAti;
-                case LibreHardwareMonitor.Hardware.HardwareType.TBalancer:
-                    return HardwareType.TBalancer;
-                case LibreHardwareMonitor.Hardware.HardwareType.Heatmaster:
-                    return HardwareType.Heatmaster;
+                case LibreHardwareMonitor.Hardware.HardwareType.Cooler:
+                    return HardwareType.Cooler;
                 case LibreHardwareMonitor.Hardware.HardwareType.Storage:
                     return HardwareType.HDD;
                 case LibreHardwareMonitor.Hardware.HardwareType.Network:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: 'Visual Studio 2017'
+image: 'Visual Studio 2019'
 install:
   - git submodule update --init --recursive
   - msbuild /t:restore

--- a/ci/Dockerfile.tests
+++ b/ci/Dockerfile.tests
@@ -1,4 +1,4 @@
-FROM mono:5
+FROM mono:6
 COPY . /tmp/
 WORKDIR /tmp
 RUN msbuild /t:restore /p:TargetFrameworks=net461 && \


### PR DESCRIPTION
Notes:
  - Several hardware types (Aquacomputer, AeroCool, Heatmaster, and TBalancer) have been consolidated into a single hardware type (Cooler). This is will be an inconvenience to users relying on those metric names.
  - I noticed that bus speed is now reported for me as part of CPU frequencies
  - LibreHardwareLib is now using C# 8 features, so CI environment needed to be upgraded