### PR TITLE
Specify timescale version to fix CI

### DIFF
--- a/ci/Dockerfile.timescale
+++ b/ci/Dockerfile.timescale
@@ -1,3 +1,3 @@
-FROM timescale/timescaledb
+FROM timescale/timescaledb:latest-pg12
 COPY ci/setup-docker.sh /docker-entrypoint-initdb.d/.
 COPY assets/schema.sql /sql/schema.sql


### PR DESCRIPTION
Timescale is no longer offering a latest docker image:
https://hub.docker.com/r/timescale/timescaledb