### PR TITLE
Allow specifying config path when ran interactive

### DIFF
--- a/OhmGraphite/CustomConfig.cs
+++ b/OhmGraphite/CustomConfig.cs
@@ -1,0 +1,17 @@
+﻿using System.Configuration;
+
+namespace OhmGraphite.Test
+{
+    class CustomConfig : IAppConfig
+    {
+        private readonly Configuration _config;
+
+        public CustomConfig(Configuration config)
+        {
+            _config = config;
+        }
+
+        public string this[string name] => _config.AppSettings.Settings[name]?.Value;
+        public string[] GetKeys() => _config.AppSettings.Settings.AllKeys;
+    }
+}


### PR DESCRIPTION
When running interactively, OhmGraphite can be passed a config path like
so:

```
.\OhmGraphite.exe run -config:"C:\apps\OhmGraphite.exe.config"
```

Closes #186 