### PR TITLE
Allow test execution with remote docker

### DIFF
--- a/OhmGraphite.Test/DockerUtils.cs
+++ b/OhmGraphite.Test/DockerUtils.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace OhmGraphite.Test
+{
+    public static class DockerUtils
+    {
+        public static string DockerEndpoint()
+        {
+            var host = Environment.GetEnvironmentVariable("DOCKER_HOST");
+            if (host != null)
+            {
+                return host;
+            }
+
+            // https://github.com/HofmeisterAn/dotnet-testcontainers/tree/aa3d573129045a26de08e1fe57ccc180b1e04108/src/DotNet.Testcontainers/Services
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                ? "unix:/var/run/docker.sock"
+                : "npipe://./pipe/docker_engine";
+        }
+    }
+
+    public sealed class IgnoreOnRemoteDockerFactAttribute : FactAttribute
+    {
+        public IgnoreOnRemoteDockerFactAttribute()
+        {
+            if (Environment.GetEnvironmentVariable("DOCKER_HOST") != null)
+            {
+                Skip = "Ignore when executing against a remote docker instance";
+            }
+        }
+    }
+}

--- a/OhmGraphite.Test/GraphiteTest.cs
+++ b/OhmGraphite.Test/GraphiteTest.cs
@@ -14,6 +14,7 @@ namespace OhmGraphite.Test
         public async void InsertGraphiteTest()
         {
             var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+                .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("graphiteapp/graphite-statsd")
                 .WithEnvironment("REDIS_TAGDB", "y")
                 .WithPortBinding(2003, assignRandomHostPort: true)
@@ -54,6 +55,7 @@ namespace OhmGraphite.Test
         public async void InsertTagGraphiteTest()
         {
             var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+                .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("graphiteapp/graphite-statsd")
                 .WithEnvironment("REDIS_TAGDB", "y")
                 .WithPortBinding(2003, assignRandomHostPort: true)

--- a/OhmGraphite.Test/InfluxTest.cs
+++ b/OhmGraphite.Test/InfluxTest.cs
@@ -17,6 +17,7 @@ namespace OhmGraphite.Test
         public async void CanInsertIntoInflux()
         {
             var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+                .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:1.8-alpine")
                 .WithEnvironment("INFLUXDB_DB", "mydb")
                 .WithEnvironment("INFLUXDB_USER", "my_user")
@@ -59,6 +60,7 @@ namespace OhmGraphite.Test
         public async void CanInsertIntoPasswordLessInfluxdb()
         {
             var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+                .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:1.8-alpine")
                 .WithEnvironment("INFLUXDB_DB", "mydb")
                 .WithEnvironment("INFLUXDB_USER", "my_user")
@@ -101,6 +103,7 @@ namespace OhmGraphite.Test
         public async void CanInsertIntoInflux2()
         {
             var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+                .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:2.0-alpine")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_MODE", "setup")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_USERNAME", "my-user")
@@ -152,6 +155,7 @@ namespace OhmGraphite.Test
         public async void CanInsertIntoInflux2Token()
         {
             var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+                .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:2.0-alpine")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_MODE", "setup")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_USERNAME", "my-user")

--- a/OhmGraphite.Test/TimescaleTest.cs
+++ b/OhmGraphite.Test/TimescaleTest.cs
@@ -14,6 +14,7 @@ namespace OhmGraphite.Test
         public async void CanSetupTimescale()
         {
             var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+                .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("timescale/timescaledb:latest-pg12")
                 .WithEnvironment("POSTGRES_PASSWORD", "123456")
                 .WithPortBinding(5432, assignRandomHostPort: true)
@@ -35,7 +36,7 @@ namespace OhmGraphite.Test
             Assert.Equal(3, Convert.ToInt32(cmd.ExecuteScalar()));
         }
 
-        [Fact, Trait("Category", "integration")]
+        [IgnoreOnRemoteDockerFact, Trait("Category", "integration")]
         public async void InsertOnlyTimescale()
         {
             var image = await new ImageFromDockerfileBuilder()


### PR DESCRIPTION
If `DOCKER_HOST` is defined then the tests will execute on that docker
instance. Should make a bit easier to debug running unix containers on
windows.