### PR TITLE
Allow hiding of sensors by glob

### DIFF
--- a/OhmGraphite.Test/ConfigTest.cs
+++ b/OhmGraphite.Test/ConfigTest.cs
@@ -124,6 +124,12 @@ namespace OhmGraphite.Test
             Assert.True(results.IsHidden("/amdcpu/0/load/1"));
             Assert.True(results.IsHidden("/amdcpu/0/load/2"));
             Assert.False(results.IsHidden("/amdcpu/0/load/3"));
+
+            Assert.True(results.IsHidden("/amdcpu/0/clock/1"));
+            Assert.True(results.IsHidden("/amdcpu/1/clock/100"));
+            Assert.True(results.IsHidden("/amdcpu/0/power/1"));
+            Assert.True(results.IsHidden("/nvidia-gpu/0/power/1"));
+            Assert.False(results.IsHidden("/nvme/0/factor/power_cycles"));
         }
 
         [Fact]

--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ There may be a sensor that is faulty on a given machine. Maybe it reports negati
 <add key="/lpc/nct6792d/temperature/1/hidden" />
 ```
 
+One can use globs to ignore a group of sensors. For instance, to hide all power sensors and hide clock sensors from an AMD CPU:
+
+```xml
+<add key="/amdcpu/*/clock/*/hidden" />
+<add key="/*/power/*/hidden" />
+``` 
+
 ### Determine Sensor Id
 
 There are several ways to determine the sensor id of a metric:

--- a/assets/hidden-sensors.config
+++ b/assets/hidden-sensors.config
@@ -8,5 +8,7 @@
 
     <add key="/amdcpu/0/load/1/hidden" />
     <add key="/amdcpu/0/load/2/hidden" />
+    <add key="/amdcpu/*/clock/*/hidden" />
+    <add key="/*/power/*/hidden" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
One can use globs to ignore a group of sensors. For instance, to hide
all power sensors and hide clock sensors from an AMD CPU:

```xml
<add key="/amdcpu/*/clock/*/hidden" />
<add key="/*/power/*/hidden" />
```

Closes #227 