### PR TITLE
Allow hardware to be disabled

### DIFF
--- a/OhmGraphite.Test/ConfigTest.cs
+++ b/OhmGraphite.Test/ConfigTest.cs
@@ -37,6 +37,14 @@ namespace OhmGraphite.Test
             Assert.Equal(2003, results.Graphite.Port);
             Assert.Equal(TimeSpan.FromSeconds(5), results.Interval);
             Assert.False(results.Graphite.Tags);
+
+            Assert.True(results.EnabledHardware.Cpu);
+            Assert.True(results.EnabledHardware.Gpu);
+            Assert.True(results.EnabledHardware.Motherboard);
+            Assert.True(results.EnabledHardware.Controller);
+            Assert.True(results.EnabledHardware.Network);
+            Assert.True(results.EnabledHardware.Ram);
+            Assert.True(results.EnabledHardware.Storage);
         }
 
         [Fact]
@@ -130,6 +138,8 @@ namespace OhmGraphite.Test
             Assert.True(results.IsHidden("/amdcpu/0/power/1"));
             Assert.True(results.IsHidden("/nvidia-gpu/0/power/1"));
             Assert.False(results.IsHidden("/nvme/0/factor/power_cycles"));
+
+            Assert.False(results.EnabledHardware.Cpu);
         }
 
         [Fact]

--- a/OhmGraphite/Program.cs
+++ b/OhmGraphite/Program.cs
@@ -20,23 +20,22 @@ namespace OhmGraphite
             {
                 x.Service<IManage>(s =>
                 {
-                    // We'll want to capture all available hardware metrics
-                    // to send to graphite
-                    var computer = new Computer
-                    {
-                        IsGpuEnabled = true,
-                        IsMotherboardEnabled = true,
-                        IsCpuEnabled = true,
-                        IsMemoryEnabled = true,
-                        IsNetworkEnabled = true,
-                        IsStorageEnabled = true,
-                        IsControllerEnabled = true
-                    };
-
                     s.ConstructUsing(name =>
                     {
                         var configDisplay = string.IsNullOrEmpty(configPath) ? "default" : configPath;
                         var config = Logger.LogFunction($"parse config {configDisplay}", () => MetricConfig.ParseAppSettings(CreateConfiguration(configPath)));
+
+                        var computer = new Computer
+                        {
+                            IsGpuEnabled = config.EnabledHardware.Gpu,
+                            IsMotherboardEnabled = config.EnabledHardware.Motherboard,
+                            IsCpuEnabled = config.EnabledHardware.Cpu,
+                            IsMemoryEnabled = config.EnabledHardware.Ram,
+                            IsNetworkEnabled = config.EnabledHardware.Network,
+                            IsStorageEnabled = config.EnabledHardware.Storage,
+                            IsControllerEnabled = config.EnabledHardware.Controller
+                        };
+
                         var collector = new SensorCollector(computer, config);
                         return CreateManager(config, collector);
                     });

--- a/README.md
+++ b/README.md
@@ -272,6 +272,26 @@ There are several ways to determine the sensor id of a metric:
 Sensor added: /lpc/nct6792d/fan/1 "Fan #2"
 ```
 
+### Disabling Hardware
+
+By default, all hardware sensor collection is enabled to allow for minimal configuration in common use cases. However, some hardware may be susceptible to instability when polled. Hiding all of the sensors from unstable hardware isn't sufficient as sensor name filtering occurs after querying hardware. Thus there is configuration to determine what hardware is enabled.
+
+The snippet below shows all the options that can be used to disable hardware.
+
+```xml
+<add key="/cpu/enabled" value="FaLsE" />
+<add key="/gpu/enabled" value="false" />
+<add key="/motherboard/enabled" value="false" />
+<add key="/ram/enabled" value="false" />
+<add key="/network/enabled" value="false" />
+<add key="/storage/enabled" value="false" />
+<add key="/controller/enabled" value="false" />
+```
+
+Since disabling sensors at the hardware level is more efficient than a glob to hide desired sensors, disabling hardware is desirable even if the underlying hardware is stable.
+
+When hardware is disabled, all instances of that hardware are disabled. For instance, if one has multiple storage devices and only one is unstable, disabling storage hardware will halt sensor collection from all of them.
+
 ### Certificates
 
 When connecting to a service that presents a self signed certificate, one can specify `certificate_verification`

--- a/assets/hidden-sensors.config
+++ b/assets/hidden-sensors.config
@@ -10,5 +10,7 @@
     <add key="/amdcpu/0/load/2/hidden" />
     <add key="/amdcpu/*/clock/*/hidden" />
     <add key="/*/power/*/hidden" />
+
+    <add key="/cpu/enabled" value="FaLsE" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
By default, all hardware sensor collection is enabled to allow for
minimal configuration in common use cases. However, some hardware may be
susceptible to instability when polled. Hiding all of the sensors from
unstable hardware isn't sufficient as sensor name filtering occurs after
querying hardware. Thus there is configuration to determine what
hardware is enabled.

The snippet below shows all the options that can be used to disable hardware.

```xml
<add key="/cpu/enabled" value="FaLsE" />
<add key="/gpu/enabled" value="false" />
<add key="/motherboard/enabled" value="false" />
<add key="/ram/enabled" value="false" />
<add key="/network/enabled" value="false" />
<add key="/storage/enabled" value="false" />
<add key="/controller/enabled" value="false" />
```

Since disabling sensors at the hardware level is more efficient than a
glob to hide desired sensors, disabling hardware is desirable even if
the underlying hardware is stable.

When hardware is disabled, all instances of that hardware are disabled.
For instance, if one has multiple storage devices and only one is
unstable, disabling storage hardware will halt sensor collection from
all of them.

Implementation note:

LibreHardwareMonitor also has this option but it is saved as

```xml
<add key="mainboardMenuItem" value="false" />
```

While I enjoy users being able to copy over some of their LHM configs,
the name doesn't make sense in this case (as we aren't dealing with menu
items here).

Instead I followed the naming precedent set forth by hiding and renaming
sensors by reusing the slash notation. It's not a perfect fit as those
are specific to hardware implementations, such as "/amdcpu/" whereas
disabling hardware looks like "/cpu/enabled". I find this discrepancy to
be tolerable.

Closes #249 
Closes #220 (as this is a good enough workaround)