### PR TITLE
Use consistent fill opacity in sample dashboard

### DIFF
--- a/assets/dashboards/ohm-prometheus.json
+++ b/assets/dashboards/ohm-prometheus.json
@@ -3089,7 +3089,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -3175,7 +3175,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -3267,7 +3267,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -4076,5 +4076,5 @@
   "timezone": "",
   "title": "Ohm Windows Desktop",
   "uid": "EEQD4wv7z",
-  "version": 40
+  "version": 41
 }


### PR DESCRIPTION
No reason to have some panels have a fillOpacity of 0 while the rest use
10.