### PR TITLE
Remove threshold lines from cpu temp sample panel

### DIFF
--- a/assets/dashboards/ohm-prometheus.json
+++ b/assets/dashboards/ohm-prometheus.json
@@ -71,7 +71,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1635542702180,
+  "iteration": 1635551124884,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -1576,7 +1576,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "line"
+              "mode": "off"
             }
           },
           "links": [],
@@ -4079,5 +4079,5 @@
   "timezone": "",
   "title": "Ohm Windows Desktop",
   "uid": "EEQD4wv7z",
-  "version": 41
+  "version": 43
 }


### PR DESCRIPTION
None of the other temperature panels contained thresholds and it didn't
seem right to add threshold to others as the threshold palette clashed
with the series palette. And I don't have the intuition to make this
color choice so the easiest thing to do is to remove it. I don't think
all is lost as since the soft max is 100 degrees, if any graph shows a
high reading it would be interpreted the same as crossing a threshold.