### PR TITLE
Set dashboard variables to refresh on time range change

### DIFF
--- a/assets/dashboards/ohm-prometheus.json
+++ b/assets/dashboards/ohm-prometheus.json
@@ -4017,7 +4017,7 @@
           "query": "{__name__=~\"ohm_nic_.*\",instance=\"$instance\"}",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/.*hardware=\"([^\"]*).*/",
         "skipUrlSync": false,
         "sort": 0,
@@ -4040,7 +4040,7 @@
           "query": "{__name__=~\"ohm_cpu_.*\",instance=\"$instance\"}",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/.*hardware=\"([^\"]*).*/",
         "skipUrlSync": false,
         "sort": 0,
@@ -4063,7 +4063,7 @@
           "query": "{__name__=~\"ohm_gpu.*\",instance=\"$instance\"}",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/.*hardware=\"([^\"]*).*/",
         "skipUrlSync": false,
         "sort": 0,
@@ -4079,5 +4079,5 @@
   "timezone": "",
   "title": "Ohm Windows Desktop",
   "uid": "EEQD4wv7z",
-  "version": 43
+  "version": 45
 }


### PR DESCRIPTION
This can clean up the dashboard a bit when one decides to view a time
range that predates a nic, disk, etc, as this will remove a blank
breakdown new disks when viewing old data.

This also makes it consistent between all the variables (some were
already configured to refresh on time range change)

ref: https://github.com/nickbabcock/OhmGraphite/issues/246#issuecomment-982563966