### PR TITLE
Bump LibreHardwareMonitor and upgrade to Net 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: true
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.*'
     - run: dotnet test
       if: matrix.os == 'ubuntu-latest'
     - run: dotnet test --filter 'Category!=integration'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         submodules: true
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.*'
     - run: dotnet publish -c Release .\OhmGraphite\
     - name: Set artifact name
       shell: bash

--- a/OhmGraphite.Test/OhmGraphite.Test.csproj
+++ b/OhmGraphite.Test/OhmGraphite.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishTrimmed>true</PublishTrimmed>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
With LibreHardwareMonitor targeting net 6.0, this PR also updates to net
6.0, as net 6.0 is the current LTS and 5.0 won't be supported in half a
year.

For LibreHardwareMonitor, the headlining change is that Alder Lake and
Jasper Lake are better supported. The other changes are [mostly minor][1].

Net 6.0 did bring with it some problems. After building the OhmGraphite
it would fail to start with the following exception:

```plain
System.ServiceProcess.TimeoutException: Time out has expired and the operation has not been completed.
System.ServiceProcess.ServiceController.WaitForStatus
```

The failure is almost certainly due to net 6.0 [trimming granularity][0]
changing from `copyused` to `link`.

However, reverting back to `copyused` didn't fix the issue either. Since
I'm unsure what is causing the issue, trimming has been disabled. This
is a bummer as trimming has a positive impact on file size. This
regression isn't apparent as I've enabled assembly compression, which
technically has a performance cost on startup but since this cost is
amoritized over the machine's uptime, hopefully it won't be too
intolerable.

[0]: https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options#trimming-granularity
[1]: LibreHardwareMonitor/LibreHardwareMonitor@1701eb9...d3a38bf