### PR TITLE
Fix pg insertion failure due to time zones

### DIFF
--- a/OhmGraphite/TimescaleWriter.cs
+++ b/OhmGraphite/TimescaleWriter.cs
@@ -30,6 +30,10 @@ namespace OhmGraphite
         {
             try
             {
+                // "timestamp with time zone" postgres type is a UTC timestamp so
+                // we explicitly convert the reported time to UTC to avoid a cast
+                // exception by npgsql
+                reportTime = reportTime.ToUniversalTime();
                 if (_failure)
                 {
                     Logger.Debug("Clearing connection pool");


### PR DESCRIPTION
Npgsql started throwing exceptions in v6.0 when handed a datetime with a
local time zone, as the server expects a date time in UTC. This bug only
effects OhmGraphite v0.23

Closes #273 