### PR TITLE
Add PSU metric reporting

### DIFF
--- a/OhmGraphite/MetricConfig.cs
+++ b/OhmGraphite/MetricConfig.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 namespace OhmGraphite
 {
     public record EnabledHardware(bool Cpu, bool Gpu, bool Motherboard, bool Ram, bool Network, bool Storage,
-        bool Controller);
+        bool Controller, bool Psu);
 
     public class MetricConfig
     {
@@ -114,7 +114,8 @@ namespace OhmGraphite
                 config["/ram/enabled"]?.ToLowerInvariant() != "false",
                 config["/network/enabled"]?.ToLowerInvariant() != "false",
                 config["/storage/enabled"]?.ToLowerInvariant() != "false",
-                config["/controller/enabled"]?.ToLowerInvariant() != "false"
+                config["/controller/enabled"]?.ToLowerInvariant() != "false",
+                config["/psu/enabled"]?.ToLowerInvariant() != "false"
             );
         }
 

--- a/OhmGraphite/Program.cs
+++ b/OhmGraphite/Program.cs
@@ -42,7 +42,8 @@ namespace OhmGraphite
                             IsMemoryEnabled = config.EnabledHardware.Ram,
                             IsNetworkEnabled = config.EnabledHardware.Network,
                             IsStorageEnabled = config.EnabledHardware.Storage,
-                            IsControllerEnabled = config.EnabledHardware.Controller
+                            IsControllerEnabled = config.EnabledHardware.Controller,
+                            IsPsuEnabled = config.EnabledHardware.Psu,
                         };
 
                         var collector = new SensorCollector(computer, config);

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ The snippet below shows all the options that can be used to disable hardware.
 <add key="/network/enabled" value="false" />
 <add key="/storage/enabled" value="false" />
 <add key="/controller/enabled" value="false" />
+<add key="/psu/enabled" value="false" />
 ```
 
 Since disabling sensors at the hardware level is more efficient than a glob to hide desired sensors, disabling hardware is desirable even if the underlying hardware is stable.


### PR DESCRIPTION
[In June of 2021, LibreHardwareMonitor gained support for reporting
metrics from the PSU][0]. This commit exposes this functionality by
default in OhmGraphite. One can opt out of sending PSU metrics with:

```xml
<add key="/controller/enabled" value="false" />
```

Closes #277 

[0]: https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/458