### PR TITLE
Fix OhmNvme error with resiliant updates

### DIFF
--- a/OhmGraphite/OhmNvme.cs
+++ b/OhmGraphite/OhmNvme.cs
@@ -56,11 +56,11 @@ namespace OhmGraphite
 
         public void Update()
         {
-            var health = _nvme.Smart.GetHealthInfo();
-            ErrorInfoLogEntryCount.Value = health.ErrorInfoLogEntryCount;
-            MediaErrors.Value = health.MediaErrors;
-            PowerCycles.Value = health.PowerCycle;
-            UnsafeShutdowns.Value = health.UnsafeShutdowns;
+            var health = _nvme?.Smart?.GetHealthInfo();
+            ErrorInfoLogEntryCount.Value = health?.ErrorInfoLogEntryCount;
+            MediaErrors.Value = health?.MediaErrors;
+            PowerCycles.Value = health?.PowerCycle;
+            UnsafeShutdowns.Value = health?.UnsafeShutdowns;
         }
     }
 }


### PR DESCRIPTION
User received the following exception in their log:

```plain
System.NullReferenceException: Object reference not set to an instance of an object.
   at OhmGraphite.OhmNvme.Update()
```

So the code has been updated avoid eagerly deferencing objects that are
null.