### PR TITLE
Update LibreHardwareMonitor to v0.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "LibreHardwareMonitor"]
-	path = LibreHardwareMonitor
-	url = https://github.com/LibreHardwareMonitor/LibreHardwareMonitor

--- a/OhmGraphite.sln
+++ b/OhmGraphite.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OhmGraphite", "OhmGraphite\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OhmGraphite.Test", "OhmGraphite.Test\OhmGraphite.Test.csproj", "{E6C3F138-BED7-4350-B1F0-95AE87640CFB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibreHardwareMonitorLib", "LibreHardwareMonitor\LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj", "{EBF013C2-0600-4439-8D16-1925A015D15B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.0" />
     <PackageReference Include="InfluxDB.Client" Version="3.3.0" />
     <PackageReference Include="Npgsql" Version="6.0.4" />
     <PackageReference Include="prometheus-net" Version="6.0.0" />
@@ -42,10 +43,6 @@
     <PackageReference Include="TopShelf" Version="4.3.0" />
     <PackageReference Include="Topshelf.NLog" Version="4.3.0" />
     <PackageReference Include="InfluxDB.LineProtocol" Version="1.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\LibreHardwareMonitor\LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj" />
   </ItemGroup>
 
   <Target Name="ZipOutputPath" AfterTargets="Publish">

--- a/OhmGraphite/Translation.cs
+++ b/OhmGraphite/Translation.cs
@@ -39,6 +39,7 @@ namespace OhmGraphite
         RAM,
         GpuNvidia,
         GpuAti,
+        GpuIntel,
         Cooler,
         HDD,
         NIC,
@@ -107,6 +108,8 @@ namespace OhmGraphite
                     return HardwareType.GpuNvidia;
                 case LibreHardwareMonitor.Hardware.HardwareType.GpuAmd:
                     return HardwareType.GpuAti;
+                case LibreHardwareMonitor.Hardware.HardwareType.GpuIntel:
+                    return HardwareType.GpuIntel;
                 case LibreHardwareMonitor.Hardware.HardwareType.Cooler:
                     return HardwareType.Cooler;
                 case LibreHardwareMonitor.Hardware.HardwareType.Storage:


### PR DESCRIPTION
Some highlights from [the new commits][0]:

- Add Intel integrated GPU sensors
- Add support for B560M AORUS PRO and B560M AORUS PRO AX
- Better detection of Samsung NVMe drives
- Support Z690 Aorus Pro
- Add EC T_Sensor for ROG Strix Z690-A
- "CPU Core" voltage sensor for intel CPU's
- IT8613E and Biostar B660GTN support
- Add X570 Aorus Ultra
- Add Gigabyte Z690 Gaming X

This commit also moves to the librehardwaremonitor nuget package which
should be updated nightly. So instead of fighting compile errors using a
git submodule, we can just pull the latest nuget package -- at least
that is the thought.

[0]: https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/compare/f0dd72add999ac1e92f178a10e326be2de607c00...v0.9.0