### PR TITLE
Update LibreHardwareMonitor from 0.9.2-pre157 to 0.9.2-pre186

### DIFF
--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.2-pre157" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.2-pre186" />
     <PackageReference Include="InfluxDB.Client" Version="4.6.0" />
     <PackageReference Include="Npgsql" Version="6.0.7" />
     <PackageReference Include="prometheus-net" Version="6.0.0" />

--- a/OhmGraphite/OhmSensor.cs
+++ b/OhmGraphite/OhmSensor.cs
@@ -35,5 +35,9 @@ namespace OhmGraphite
         public void ResetMax()
         {
         }
+
+        public void ClearValues()
+        {
+        }
     }
 }


### PR DESCRIPTION
Updates https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/compare/58cef11...1131b4

- Fix incorrect readings of GPU power wattage
- Add support for Zen4 SMU
- Add support for HX1500i and HX1000i
- Add support for Nuvoton NCT6799D
- Add support for Asus Z790 Max Hero