### PR TITLE
HTTPS support for Prometheus Exporter

### DIFF
--- a/OhmGraphite/Program.cs
+++ b/OhmGraphite/Program.cs
@@ -111,7 +111,7 @@ namespace OhmGraphite
             {
                 Logger.Info($"Prometheus port: {config.Prometheus.Port}");
                 var registry = PrometheusCollection.SetupDefault(collector);
-                var server = new MetricServer(config.Prometheus.Host, config.Prometheus.Port, registry: registry);
+                var server = new MetricServer(config.Prometheus.Host, config.Prometheus.Port, registry: registry, useHttps: config.Prometheus.UseHttps);
                 return new PrometheusServer(server, collector);
             }
             else if (config.Timescale != null)

--- a/OhmGraphite/PrometheusConfig.cs
+++ b/OhmGraphite/PrometheusConfig.cs
@@ -1,5 +1,3 @@
-﻿using LibreHardwareMonitor.Hardware.Controller.AeroCool;
-
 namespace OhmGraphite
 {
     public class PrometheusConfig

--- a/OhmGraphite/PrometheusConfig.cs
+++ b/OhmGraphite/PrometheusConfig.cs
@@ -1,25 +1,33 @@
-﻿namespace OhmGraphite
+﻿using LibreHardwareMonitor.Hardware.Controller.AeroCool;
+
+namespace OhmGraphite
 {
     public class PrometheusConfig
     {
         public int Port { get; }
         public string Host { get; }
+        public bool UseHttps { get; }
 
-        public PrometheusConfig(int port, string host)
+        public PrometheusConfig(int port, string host, bool useHttps)
         {
             Port = port;
             Host = host;
+            UseHttps = useHttps;
         }
 
         internal static PrometheusConfig ParseAppSettings(IAppConfig config)
         {
             string host = config["prometheus_host"] ?? "*";
+            if (!bool.TryParse(config["prometheus_https"], out bool useHttps))
+            {
+                useHttps = false;
+            }
             if (!int.TryParse(config["prometheus_port"], out int port))
             {
                 port = 4445;
             }
 
-            return new PrometheusConfig(port, host);
+            return new PrometheusConfig(port, host, useHttps);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ Configuring the Prometheus exporter will create a server that listens on `promet
          `*` means that it will listen on all interfaces.
          Consider restricting to a given IP address -->
     <add key="prometheus_host" value="*" />
+	<add key="prometheus_https" value="false" />
   </appSettings>
 </configuration>
 ```
+(Note: If HTTPS is enabled you must also [configure a certificate in windows](https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/how-to-configure-a-port-with-an-ssl-certificate).)
 
 Then you'll need add the OhmGraphite instance to your [Prometheus config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/). This can be done with the method of your choosing but for the sake of example here is a possible `prometheus.yml`:
 


### PR DESCRIPTION
Now possible to configure Prometheus config to enable HTTPS support. Readme also updated to reflect changes.

As discussed https://github.com/nickbabcock/OhmGraphite/issues/377.

Best Regards,