### PR TITLE
Update LibreHardwareMonitorLib from v0.9.2-209 to v0.9.3-243

### DIFF
--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.2-pre209" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.3-pre243" />
     <PackageReference Include="InfluxDB.Client" Version="4.12.0" />
     <PackageReference Include="Npgsql" Version="7.0.4" />
     <PackageReference Include="prometheus-net" Version="6.0.0" />


### PR DESCRIPTION
- Add support for Razer PWM PC Fan Controller
- Add support for IT87952E EC on Gigabyte boards
- Add partially support for MS-7751 boards (F71889AD)
- Add support for ASUS ROG CROSSHAIR X670E GENE
- Add support for Gigabyte B75M-D3H
- Add support for ASUS ROG Z390-E Gaming Motherboard
- Added fan control support for the EVGA X58 3X SLI motherboard
- Create virtual sensor for maximum CPU load across all cores
- Support asus rog strix z390-i gaming embedded controller 
- Add support for Gigabyte B550 Aorus Pro sensors
- Support Asus ROG STRIX Z390-F GAMING
- Add support for IPMI sensors and Supermicro IPMI fan control