### PR TITLE
Allow hiding sensors by sensor name

### DIFF
--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -152,7 +152,7 @@ namespace OhmGraphite
             {
                 Logger.Debug($"{id} had an infinite value");
             }
-            else if (!_config.IsHidden(sensor.Identifier.ToString()))
+            else if (!_config.IsHidden(sensor.Identifier.ToString()) && !_config.IsHidden(sensor.Name))
             {
                 var hwInstance = sensor.Hardware.Identifier.ToString();
                 var ind = hwInstance.LastIndexOf('/');


### PR DESCRIPTION
LibrehardwareMonitor recently started reporting the maximum CPU load across all cores (#381) (https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1047).

This is pretty redundant for OhmGraphite, which is better equip to slice and dice the data as desired. Throwing in a virtual sensor kinda mucks things up.

OhmGraphite has the ability to hide sensors through the sensor ID, and when I went to look up the sensor ID for this new sensor, I saw:

```
/amdcpu/0/load/1 "CPU Core Max"
```

And then I realized that hiding purely on sensor ID is lackluster when it would be much clearer to hide based on sensor name.

This commit adds the ability to hide sensors based on name:

```
<add key="CPU Core Max/hidden" />
```