### PR TITLE
Migrate to supported testcontainers dependency

### DIFF
--- a/OhmGraphite.Test/GraphiteTest.cs
+++ b/OhmGraphite.Test/GraphiteTest.cs
@@ -1,8 +1,7 @@
+using DotNet.Testcontainers.Builders;
 using System;
 using System.Net.Http;
 using System.Threading;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
 using Xunit;
 
 namespace OhmGraphite.Test
@@ -12,7 +11,7 @@ namespace OhmGraphite.Test
         [Fact, Trait("Category", "integration")]
         public async void InsertGraphiteTest()
         {
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("graphiteapp/graphite-statsd:1.1.8-2")
                 .WithEnvironment("REDIS_TAGDB", "y")
@@ -53,7 +52,7 @@ namespace OhmGraphite.Test
         [Fact, Trait("Category", "integration")]
         public async void InsertTagGraphiteTest()
         {
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("graphiteapp/graphite-statsd:1.1.8-2")
                 .WithEnvironment("REDIS_TAGDB", "y")

--- a/OhmGraphite.Test/InfluxTest.cs
+++ b/OhmGraphite.Test/InfluxTest.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
 using InfluxDB.Client;
 using Xunit;
 
@@ -16,7 +15,7 @@ namespace OhmGraphite.Test
         [Fact, Trait("Category", "integration")]
         public async void CanInsertIntoInflux()
         {
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:1.8-alpine")
                 .WithEnvironment("INFLUXDB_DB", "mydb")
@@ -59,7 +58,7 @@ namespace OhmGraphite.Test
         [Fact, Trait("Category", "integration")]
         public async void CanInsertIntoPasswordLessInfluxdb()
         {
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:1.8-alpine")
                 .WithEnvironment("INFLUXDB_DB", "mydb")
@@ -102,7 +101,7 @@ namespace OhmGraphite.Test
         [Fact, Trait("Category", "integration")]
         public async void CanInsertIntoInflux2()
         {
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:2.0-alpine")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_MODE", "setup")
@@ -154,7 +153,7 @@ namespace OhmGraphite.Test
         [Fact, Trait("Category", "integration")]
         public async void CanInsertIntoInflux2Token()
         {
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:2.0-alpine")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_MODE", "setup")
@@ -208,7 +207,7 @@ namespace OhmGraphite.Test
             // We do some fancy docker footwork where we informally connect
             // these two containers. In the future I believe test containers will
             // be able to natively handle adding these to a docker network
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("influxdb:2.0-alpine")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_MODE", "setup")
@@ -224,7 +223,7 @@ namespace OhmGraphite.Test
             await container.StartAsync();
 
             var cmd = $"apk add openssl && openssl req -x509 -nodes -newkey rsa:4096 -keyout /tmp/key.pem -out /tmp/cert.pem -days 365 -subj '/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=www.example.com' && /usr/bin/ghostunnel server --listen=0.0.0.0:8087 --target={container.IpAddress}:8086 --unsafe-target --disable-authentication --key /tmp/key.pem --cert=/tmp/cert.pem";
-            var tlsContainerBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var tlsContainerBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("squareup/ghostunnel")
                 .WithExposedPort(8087)

--- a/OhmGraphite.Test/OhmGraphite.Test.csproj
+++ b/OhmGraphite.Test/OhmGraphite.Test.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Testcontainers" Version="3.3.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2" />

--- a/OhmGraphite.Test/TimescaleTest.cs
+++ b/OhmGraphite.Test/TimescaleTest.cs
@@ -1,6 +1,5 @@
 using System;
 using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
 using Npgsql;
 using Xunit;
 
@@ -11,7 +10,7 @@ namespace OhmGraphite.Test
         [Fact, Trait("Category", "integration")]
         public async void CanSetupTimescale()
         {
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithDockerEndpoint(DockerUtils.DockerEndpoint())
                 .WithImage("timescale/timescaledb:latest-pg12")
                 .WithEnvironment("POSTGRES_PASSWORD", "123456")
@@ -37,14 +36,15 @@ namespace OhmGraphite.Test
         [IgnoreOnRemoteDockerFact, Trait("Category", "integration")]
         public async void InsertOnlyTimescale()
         {
-            var image = await new ImageFromDockerfileBuilder()
+            var image = new ImageFromDockerfileBuilder()
                 .WithDockerfile("timescale.dockerfile")
                 .WithDockerfileDirectory("docker")
                 .WithDeleteIfExists(true)
                 .WithName("ohm-graphite-insert-only-timescale")
                 .Build();
+            await image.CreateAsync();
 
-            var testContainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+            var testContainersBuilder = new ContainerBuilder()
                 .WithImage(image)
                 .WithEnvironment("POSTGRES_PASSWORD", "123456")
                 .WithPortBinding(5432, assignRandomHostPort: true)


### PR DESCRIPTION
The old dependency recommended migrating to this one (and I think they are run by the same crew)