### PR TITLE
Bump to LibreHardwareMonitor 0.9.3

### DIFF
--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.3-pre256" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.3" />
     <PackageReference Include="InfluxDB.Client" Version="4.14.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />

--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -113,7 +113,7 @@ namespace OhmGraphite
         {
             var added = _ids.TryAdd(sensor.Identifier, sensor);
             var msg = added ? "Sensor added: {0} \"{1}\"" : "Sensor previously added: {0} \"{1}\"";
-            Logger.Info(msg, sensor.Identifier, sensor.Name);
+            Logger.Info(msg, sensor.Identifier, SensorName(sensor));
         }
 
         private void SensorRemoved(ISensor sensor)
@@ -133,15 +133,19 @@ namespace OhmGraphite
             return _ids.Values.OfType<ISensor>().SelectMany(ReportedValues);
         }
 
-        private IEnumerable<ReportedValue> ReportedValues(ISensor sensor)
+        private string SensorName(ISensor sensor)
         {
             // Remove hardware index indentifier for motherboards to preserve
             // librehardwaremonitor pre-0.9.3 behavior
             // https://github.com/nickbabcock/OhmGraphite/pull/433
-            string named = sensor.Hardware.HardwareType == LibreHardwareMonitor.Hardware.HardwareType.Motherboard
+            return sensor.Hardware.HardwareType == LibreHardwareMonitor.Hardware.HardwareType.Motherboard
                 ? string.Join("/", sensor.Name.Split('/').Where((x, i) => i != 2))
                 : sensor.Name;
+        }
 
+        private IEnumerable<ReportedValue> ReportedValues(ISensor sensor)
+        {
+            string sensorName = SensorName(sensor);
             string id = sensor.Identifier.ToString();
 
             // Only report a value if the sensor was able to get a value
@@ -159,13 +163,13 @@ namespace OhmGraphite
             {
                 Logger.Debug($"{id} had an infinite value");
             }
-            else if (!_config.IsHidden(sensor.Identifier.ToString()) && !_config.IsHidden(named))
+            else if (!_config.IsHidden(sensor.Identifier.ToString()) && !_config.IsHidden(sensorName))
             {
                 var hwInstance = sensor.Hardware.Identifier.ToString();
                 var ind = hwInstance.LastIndexOf('/');
                 hwInstance = hwInstance.Substring(ind + 1);
 
-                var name = _config.TryGetAlias(sensor.Identifier.ToString(), out string alias) ? alias : named;
+                var name = _config.TryGetAlias(sensor.Identifier.ToString(), out string alias) ? alias : sensorName;
 
                 yield return new ReportedValue(id,
                     name,


### PR DESCRIPTION
There's a breaking change in LHW with the [introduction of the index of superIO identifier][0]:

Before:

```
/lpc/nct6792d/control/0 "Fan #1"
```

After:

```
/lpc/nct6792d/0/control/0 "Fan #1"
```

I'm open to discussion on what the right course of action should be:

1. ~~Preserve the breaking change and just note it in the changelog~~
2. Introduce logic to keep the same sensor IDs (but what to do with new users with systems that eventually see the motherboard hardware split in two, which would experience duplicate sensor IDs or a breaking change in IDs if we only introduced indices if multiple exist).
3. ~~Introduce a config in OhmGraphite so the user can choose between 1 and 2 (and default to 2)~~

Option "2" was chosen as it allows us to punt the decision down the road in a "wait and see" scenario.

Another user visible change is that there is a new metric for storage metrics: "Read Activity" which is analogous to the already present Total and Write Activity sensors but for reading.

- Add read activity to storage
- Add support for MSI MPG X570 GAMING PLUS (MS-7C37)
- Add support for ASUS ROG STRIX X670E-F GAMING WIFI
- Add support Asus ROG MAXIMUS XI FORMULA

[0]: https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1183