### PR TITLE
Improve CPU/mem efficiency by avoiding tracking multiple values

### DIFF
--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NLog;
 using LibreHardwareMonitor.Hardware;
 using LibreHardwareMonitor.Hardware.Storage;
+using System;
 
 namespace OhmGraphite
 {
@@ -111,6 +112,7 @@ namespace OhmGraphite
 
         private void SensorAdded(ISensor sensor)
         {
+            sensor.ValuesTimeWindow = TimeSpan.Zero;
             var added = _ids.TryAdd(sensor.Identifier, sensor);
             var msg = added ? "Sensor added: {0} \"{1}\"" : "Sensor previously added: {0} \"{1}\"";
             Logger.Info(msg, sensor.Identifier, SensorName(sensor));


### PR DESCRIPTION
By default, LibreHardwareMonitor will track 24 hours worth of values, this does not bode well for CPU (which needs to manage the in memory list) as well as memory usage.

This commit improves the efficiency by not tracking existing values (as this is for the the downstream metric store).

In practice memory usage fell by ~3MB and change CPU seemed negligible, but it's better than nothing!