### PR TITLE
Update LibreHardwareMonitor to latest

### DIFF
--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.3" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4-pre277" />
     <PackageReference Include="InfluxDB.Client" Version="4.14.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />

--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -81,6 +81,8 @@ namespace OhmGraphite
                         return "control_percent";
                     case SensorType.Level: // %
                         return "level_percent";
+                    case SensorType.Humidity: // %
+                        return "humidity_percent";
                     case SensorType.Fan: // RPM
                         return "revolutions_per_minute";
                     case SensorType.Flow: // L/h

--- a/OhmGraphite/Translation.cs
+++ b/OhmGraphite/Translation.cs
@@ -25,7 +25,8 @@ namespace OhmGraphite
         Throughput, // B/s
         TimeSpan, // Seconds
         Energy, // milliwatt-hour (mWh)
-        Noise // dBA
+        Noise, // dBA
+        Humidity, // %
     }
 
     /// <summary>
@@ -91,6 +92,8 @@ namespace OhmGraphite
                     return SensorType.Energy;
                 case LibreHardwareMonitor.Hardware.SensorType.Noise:
                     return SensorType.Noise;
+                case LibreHardwareMonitor.Hardware.SensorType.Humidity:
+                    return SensorType.Humidity;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(s), s, "unexpected hardware monitor sensor translation");
             }


### PR DESCRIPTION
- Add support for Intel Gen 14 Meteor Lake
- Add Humidity Sensors support
- Add support for ASUS Proart X670E Creator WiFi
- Add support for Gigabyte Z690 AORUS MASTER
- Add support for GIGABYTE B560I AORUS PRO AX
- Add support for B650M_AORUS_PRO_AX
- Add support for ADL pmlog
- Fix crash when access to nvml api is unavailable
- Fix heap corruption caused by incorrect pointer size in calls to Ftd2xx.dll
- Fix metrics on newer gpus