### PR TITLE
Bump librehardware monitor to latest

### DIFF
--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4-pre277" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4-pre339" />
     <PackageReference Include="InfluxDB.Client" Version="4.15.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />

--- a/OhmGraphite/PrometheusCollection.cs
+++ b/OhmGraphite/PrometheusCollection.cs
@@ -95,6 +95,8 @@ namespace OhmGraphite
                         return "watt_hours";
                     case SensorType.Noise:
                         return "dba";
+                    case SensorType.Conductivity:
+                        return "microsiemens_per_centimeter";
                     case SensorType.Factor: // 1
                     default:
                         return report.SensorType.ToString().ToLowerInvariant();

--- a/OhmGraphite/Translation.cs
+++ b/OhmGraphite/Translation.cs
@@ -27,6 +27,7 @@ namespace OhmGraphite
         Energy, // milliwatt-hour (mWh)
         Noise, // dBA
         Humidity, // %
+        Conductivity, // µS/cm
     }
 
     /// <summary>
@@ -94,6 +95,8 @@ namespace OhmGraphite
                     return SensorType.Noise;
                 case LibreHardwareMonitor.Hardware.SensorType.Humidity:
                     return SensorType.Humidity;
+                case LibreHardwareMonitor.Hardware.SensorType.Conductivity:
+                    return SensorType.Conductivity;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(s), s, "unexpected hardware monitor sensor translation");
             }


### PR DESCRIPTION
- Improved support for AMD GPUs
- Add shared memory free/total for Intel iGPU
- Add support for platform energy counter for Intel CPUs
- Support for ASUS Z790-E GAMING WIFI
- Support for ROG MAXIMUS Z690 HERO
- Support for Asrock H61M-DGS
- Fix memory size calculation with extended size
- Fix signedness of LPC/EC sensor readings
- Add Aquastream Ultimate support
- Add NZXT kraken X
- Add 16th voltage input for NCT67xxD chips
- Fix incorrect fan and temp readings on IT8655E
- Fix AccessViolationException crash for AMD Radeon RAMDisk
- Add Aqua Computer high flow NEXT support

Sensor name updates:

- VBat -> CMOS Battery
- CPU SA -> CPU System Agent
- VTT -> CPU Voltage Termination
- 3VSB -> +3V Standby