### PR TITLE
Update target framework from .net 6 to .net 8

### DIFF
--- a/OhmGraphite.Test/OhmGraphite.Test.csproj
+++ b/OhmGraphite.Test/OhmGraphite.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>


### PR DESCRIPTION
.net 6 support status ends in a few weeks, so this commit bumps the target framework to the next LTS: .net 8, whose support ends in 2 years.

https://endoflife.date/dotnet