### PR TITLE
Bump LibreHardwareMonitor to latest

### DIFF
--- a/OhmGraphite.Test/SensorCollectorTest.cs
+++ b/OhmGraphite.Test/SensorCollectorTest.cs
@@ -42,5 +42,17 @@ namespace OhmGraphite.Test
             var removedCount = collector.ReadAllSensors().Count();
             Assert.True(addedCount > removedCount, "addedCount > removedCount");
         }
+
+        [Theory]
+        [InlineData("/amdcpu/0", "0")]
+        [InlineData("/nvme/1", "1")]
+        [InlineData("/ram", "ram")]
+        [InlineData("/nct6792d/0", "0")]
+        [InlineData("/nic/%7BDBC40827-A257-41FA-84F5-ACBB6A148017%7D", "DBC40827-A257-41FA-84F5-ACBB6A148017")]
+        public void ExtractHardwareInstance_ReturnsCorrectValue(string input, string expected)
+        {
+            var actual = SensorCollector.ExtractHardwareInstance(input);
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.4-pre339" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre396" />
     <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.2" />

--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -167,10 +167,7 @@ namespace OhmGraphite
             }
             else if (!_config.IsHidden(sensor.Identifier.ToString()) && !_config.IsHidden(sensorName))
             {
-                var hwInstance = sensor.Hardware.Identifier.ToString();
-                var ind = hwInstance.LastIndexOf('/');
-                hwInstance = hwInstance.Substring(ind + 1);
-
+                var hwInstance = ExtractHardwareInstance(sensor.Hardware.Identifier.ToString());
                 var name = _config.TryGetAlias(sensor.Identifier.ToString(), out string alias) ? alias : sensorName;
                 var result = new ReportedValue(id,
                     name,
@@ -195,6 +192,14 @@ namespace OhmGraphite
 
                 yield return result;
             }
+        }
+
+        public static string ExtractHardwareInstance(string hwInstance)
+        {
+            var ind = hwInstance.LastIndexOf('/');
+            hwInstance = hwInstance.Substring(ind + 1);
+            hwInstance = hwInstance.Replace("%7B", "").Replace("%7D", "");
+            return hwInstance;
         }
     }
 }


### PR DESCRIPTION
- Ryzen 9000 support
- Arrow lake support
- Elkhart lake support
- Sapphire rapids support
- Lunar lake support
- Ryzen 9000 Core Frequency Bugfix
- More precise system utilization
- Add support for kraken elite 2024
- Bunch of motherboard improvements

There is a breaking change in metric names. It seems like the identifier in network devices `{DBC40827-A257-41FA-84F5-ACBB6A148017}` now are escaped: `%7BDBC40827-A257-41FA-84F5-ACBB6A148017%7D`. This is unfortunate, so I've removed these escaped characters from the instance name.