### PR TITLE
Bump LibreHardwareMonitor to latest

### DIFF
--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre396" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre407" />
     <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.2" />


### PR DESCRIPTION
- Support for AM5 motherboards
- Support for Gigabyte X670E AORUS XTREME
- Support for ASRock B850M Steel Legend Wifi
- Fix Aquacomputer Farbwerk sensor data out of sync