### PR TITLE
Bump librehardwaremonitor to latest

### DIFF
--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre407" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre441" />
     <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre441" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre447" />
     <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />

--- a/OhmGraphite/Worker.cs
+++ b/OhmGraphite/Worker.cs
@@ -40,6 +40,7 @@ namespace OhmGraphite
                 IsControllerEnabled = config.EnabledHardware.Controller,
                 IsPsuEnabled = config.EnabledHardware.Psu,
                 IsBatteryEnabled = config.EnabledHardware.Battery,
+                IsRing0Enabled = false,
             };
 
             var collector = new SensorCollector(computer, config);


### PR DESCRIPTION
**NIGHTLY BUILD TO TEST OUT DISABLING RING0**: https://github.com/nickbabcock/OhmGraphite/actions/runs/17528175249?pr=507

Update LibreHardwareMonitor to latest:

  - **Breaking Change:** Virtual and Physical ram now have separate hardware identifiers: `/vram` and `/ram` respectively -- will require a dashboard update.
  - Add individual DIMM temperature sensors (when supported)
  - Motherboard support:
    - MSI: PRO Z890 WIFI (NCT6687D), B850M Mortar, B840 PRO WIFI, Pro Z890-A WiFi (MS-7E32), MPG B850 EDGE TI WIFI
    - ASUS: ROG STRIX X870-I Gaming WIFI, ROG STRIX B760-I GAMING WIFI, ROG STRIX B850-I GAMING WIFI, STRIX Z790-E WIFI II
    - Gigabyte: X870 AORUS ELITE WIFI7 (ITE IT8696E, IT87952E), B360M H
    - ASRock: B450M Pro4 R2.0, B850M Steel Legend Wifi
  - Improved detection for Samsung NVMe devices
  - Fix with USB devices crashes and NCT6701D chip issues