### PR TITLE
Update to latest LibreHardwareMonitor lib, implicitly disable winring0, bump version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.sh text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/OhmGraphite.Test/GraphiteTest.cs
+++ b/OhmGraphite.Test/GraphiteTest.cs
@@ -19,7 +19,7 @@ namespace OhmGraphite.Test
                 .WithPortBinding(2003, assignRandomHostPort: true)
                 .WithPortBinding(80, assignRandomHostPort: true)
                 .WithPortBinding(8080, assignRandomHostPort: true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8080));
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8080));
 
             await using var container = testContainersBuilder.Build();
             await container.StartAsync();
@@ -60,7 +60,7 @@ namespace OhmGraphite.Test
                 .WithPortBinding(2003, assignRandomHostPort: true)
                 .WithPortBinding(80, assignRandomHostPort: true)
                 .WithPortBinding(8080, assignRandomHostPort: true)
-                                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8080));
+                                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8080));
 
             await using var container = testContainersBuilder.Build();
             await container.StartAsync();

--- a/OhmGraphite.Test/InfluxTest.cs
+++ b/OhmGraphite.Test/InfluxTest.cs
@@ -23,7 +23,7 @@ namespace OhmGraphite.Test
                 .WithEnvironment("INFLUXDB_USER", "my_user")
                 .WithEnvironment("INFLUXDB_USER_PASSWORD", "my_pass")
                 .WithPortBinding(8086, assignRandomHostPort: true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8086));
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8086));
 
             await using var container = testContainersBuilder.Build();
             await container.StartAsync();
@@ -66,7 +66,7 @@ namespace OhmGraphite.Test
                 .WithEnvironment("INFLUXDB_USER", "my_user")
                 .WithEnvironment("INFLUXDB_HTTP_AUTH_ENABLED", "false")
                 .WithPortBinding(8086, assignRandomHostPort: true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8086));
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8086));
 
             await using var container = testContainersBuilder.Build();
             await container.StartAsync();
@@ -111,7 +111,7 @@ namespace OhmGraphite.Test
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_BUCKET", "mydb")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_ORG", "myorg")
                 .WithPortBinding(8086, assignRandomHostPort: true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8086));
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8086));
 
             await using var container = testContainersBuilder.Build();
             await container.StartAsync();
@@ -164,7 +164,7 @@ namespace OhmGraphite.Test
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_ORG", "myorg")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", "thisistheinfluxdbtoken")
                 .WithPortBinding(8086, assignRandomHostPort: true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8086));
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8086));
 
             await using var container = testContainersBuilder.Build();
             await container.StartAsync();
@@ -218,7 +218,7 @@ namespace OhmGraphite.Test
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_ORG", "myorg")
                 .WithEnvironment("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", "thisistheinfluxdbtoken")
                 .WithPortBinding(8086, assignRandomHostPort: true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8086));
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8086));
 
             await using var container = testContainersBuilder.Build();
             await container.StartAsync();
@@ -229,7 +229,7 @@ namespace OhmGraphite.Test
                 .WithImage("squareup/ghostunnel")
                 .WithExposedPort(8087)
                 .WithPortBinding(8087, assignRandomHostPort: true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8087))
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8087))
                 .WithEntrypoint("/bin/sh")
                 .WithCommand("-c", cmd);
 

--- a/OhmGraphite.Test/OhmGraphite.Test.csproj
+++ b/OhmGraphite.Test/OhmGraphite.Test.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Testcontainers" Version="4.6.0" />
+    <PackageReference Include="Testcontainers" Version="4.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageReference Include="xunit.runner.console" Version="2.9.3" />

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -15,8 +15,8 @@
     <Description>Extract hardware sensor data and exports it to a given host and port in a graphite compatible format</Description>
     <Copyright>Nick Babcock</Copyright>
     <Major>0</Major>
-    <Minor>35</Minor>
-    <Revision>1</Revision>
+    <Minor>36</Minor>
+    <Revision>0</Revision>
     <AssemblyVersion>$(Major).$(Minor).$(Revision)</AssemblyVersion>
     <AssemblyFileVersion>$(Major).$(Minor).$(Revision)</AssemblyFileVersion>
     <InformationalVersion>$(Major).$(Minor).$(Revision)</InformationalVersion>

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre407" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre464" />
     <PackageReference Include="InfluxDB.Client" Version="4.18.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.8" />

--- a/OhmGraphite/Translation.cs
+++ b/OhmGraphite/Translation.cs
@@ -24,6 +24,7 @@ namespace OhmGraphite
         SmallData, // MB = 2^20 Bytes
         Throughput, // B/s
         TimeSpan, // Seconds
+        Timing, // nanoseconds
         Energy, // milliwatt-hour (mWh)
         Noise, // dBA
         Humidity, // %
@@ -89,6 +90,8 @@ namespace OhmGraphite
                     return SensorType.Throughput;
                 case LibreHardwareMonitor.Hardware.SensorType.TimeSpan:
                     return SensorType.TimeSpan;
+                case LibreHardwareMonitor.Hardware.SensorType.Timing:
+                    return SensorType.Timing;
                 case LibreHardwareMonitor.Hardware.SensorType.Energy:
                     return SensorType.Energy;
                 case LibreHardwareMonitor.Hardware.SensorType.Noise:


### PR DESCRIPTION
Borrowing from https://github.com/nickbabcock/OhmGraphite/pull/507 I bumped the LHM version to latest on nuget.org, removed the (short-lived) IsRing0Enabled flag, and also revved the version since this is a big-ish change.