### PR TITLE
Fixed instance regex for Prometheus dashboard

### DIFF
--- a/assets/dashboards/ohm-prometheus.json
+++ b/assets/dashboards/ohm-prometheus.json
@@ -4790,7 +4790,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
-        "regex": "/.*instance=\"([^\"]*).*/",
+        "regex": "/[^_]*instance=\"([^\"]*).*/",
         "type": "query"
       },
       {


### PR DESCRIPTION
Updated the `instance` regex so it does not match on labels such as `hw_instance`.