### PR TITLE
Bump LibreHardwareMonitorLib 0.9.5-pre472 -> 0.9.7-pre649

### DIFF
--- a/OhmGraphite.Test/OhmGraphite.Test.csproj
+++ b/OhmGraphite.Test/OhmGraphite.Test.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>8</LangVersion>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.5-pre472" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.7-pre649" />
     <PackageReference Include="InfluxDB.Client" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />

--- a/OhmGraphite/OhmNvme.cs
+++ b/OhmGraphite/OhmNvme.cs
@@ -1,15 +1,18 @@
-﻿using LibreHardwareMonitor.Hardware;
+﻿using System.Linq;
+using DiskInfoToolkit;
+using DiskInfoToolkit.Interop.Enums;
+using LibreHardwareMonitor.Hardware;
 using LibreHardwareMonitor.Hardware.Storage;
 
 namespace OhmGraphite
 {
-    // LibreHardwareMonitor doesn't expose all the SMART attributes on a generic NVMe drive
-    // so we create our own pseudo-hardware class that exposes some important factors
+    // LibreHardwareMonitor doesn't expose all the SMART attributes we want on NVMe storage
+    // so we create our own pseudo-hardware wrapper that exposes some important factors.
     internal class OhmNvme
     {
-        private readonly NVMeGeneric _nvme;
+        private readonly StorageDevice _nvme;
 
-        public OhmNvme(NVMeGeneric nvme)
+        public OhmNvme(StorageDevice nvme)
         {
             _nvme = nvme;
             var factor = LibreHardwareMonitor.Hardware.SensorType.Factor.ToString().ToLowerInvariant();
@@ -56,11 +59,18 @@ namespace OhmGraphite
 
         public void Update()
         {
-            var health = _nvme?.Smart?.GetHealthInfo();
-            ErrorInfoLogEntryCount.Value = health?.ErrorInfoLogEntryCount;
-            MediaErrors.Value = health?.MediaErrors;
-            PowerCycles.Value = health?.PowerCycle;
-            UnsafeShutdowns.Value = health?.UnsafeShutdowns;
+            var smart = _nvme?.Storage?.Smart;
+            ErrorInfoLogEntryCount.Value = SmartValue(smart, SmartAttributeType.NumberOfErrorInformationLogEntries);
+            MediaErrors.Value = SmartValue(smart, SmartAttributeType.MediaAndDataIntegrityErrors);
+            PowerCycles.Value = SmartValue(smart, SmartAttributeType.PowerCycleCount);
+            UnsafeShutdowns.Value = SmartValue(smart, SmartAttributeType.UnsafeShutdownCount);
+        }
+
+        private static float? SmartValue(SmartInfo smart, SmartAttributeType type)
+        {
+            return smart?.SmartAttributes
+                ?.FirstOrDefault(attribute => attribute.Info.Type == type)
+                ?.Attribute.RawValueULong;
         }
     }
 }

--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -41,7 +41,7 @@ namespace OhmGraphite
 
             if (PawnIo.IsInstalled)
             {
-                Logger.Info("Detected PawnIo version ({0}) installed", PawnIo.Version());
+                Logger.Info("Detected PawnIo version ({0}) installed", PawnIo.Version);
             }
             else
             {
@@ -85,7 +85,7 @@ namespace OhmGraphite
                 SensorAdded(sensor);
             }
 
-            if (hardware is NVMeGeneric nvme)
+            if (hardware is StorageDevice nvme && nvme.Storage.IsNVMe)
             {
                 var ohmNvme = new OhmNvme(nvme);
                 _nvmes.TryAdd(hardware.Identifier, ohmNvme);

--- a/OhmGraphite/Translation.cs
+++ b/OhmGraphite/Translation.cs
@@ -50,6 +50,7 @@ namespace OhmGraphite
         PSU,
         EmbeddedController,
         Battery,
+        PowerMonitor,
     }
 
     public static class TranslationExtension
@@ -135,6 +136,8 @@ namespace OhmGraphite
                     return HardwareType.EmbeddedController;
                 case LibreHardwareMonitor.Hardware.HardwareType.Battery:
                     return HardwareType.Battery;
+                case LibreHardwareMonitor.Hardware.HardwareType.PowerMonitor:
+                    return HardwareType.PowerMonitor;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(s), s, "unexpected hardware monitor hardware translation");
             }


### PR DESCRIPTION
Upstream changes: [4534276f...273b47b4](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/compare/4534276fb6b9484c5959ab042aeaadfe8eb5eac8...273b47b462223d6237e504455465722ae4baaac2).

- Added Intel discrete GPU support, including VRAM, bandwidth, and additional Intel GPU telemetry.
- Added Intel iGPU IGCL telemetry sensors (temperature, clock, voltage) and fixed duplicate integrated GPU entries.
- Added NVIDIA core voltage sensors, Astral GPU sensors, and more precise RTX 50XX core temperature readings.
- Added sensors for Framework laptops.
- Improved storage detection and polling reliability, including force-drive wakeup support, restored NVMe thermal reporting, and fixes for ATA storage update issues.
- Better handling for DIMM identifiers and battery custom names.
- Added ARCTIC fan controller support, MSI AIO controller support, Thermal Grizzly WireView Pro 2 support and controls, and MSI MEG Ai1300P PSU support.
- Added Lenovo V50t Gen 2 support.
- Added broad motherboard coverage across MSI B840/B850/X870(E)/Z890, ASUS B450/B760/B850/X670E/X870E/Z690/Z170, Gigabyte A320/B650/X870, and ASRock X870E boards.
- Fixed high CPU usage and several motherboard sensor issues, including ASUS Z170 EC zero-value temperatures, NCT67xx/NCT6799D register handling, and MSI pump and fan reporting.
- Fixed duplicate GPU memory reporting and improved D3D-friendly device names.