### PR TITLE
Add environment variable expansion support in configuration

### DIFF
--- a/OhmGraphite.Test/ConfigTest.cs
+++ b/OhmGraphite.Test/ConfigTest.cs
@@ -143,6 +143,63 @@ namespace OhmGraphite.Test
         }
 
         [Fact]
+        public void ExpandsPercentStyleEnvVars()
+        {
+            Environment.SetEnvironmentVariable("OHM_TEST_TOKEN", "secret123");
+            try
+            {
+                Assert.Equal("secret123", OhmGraphite.CustomConfig.Expand("influx2_token", "%OHM_TEST_TOKEN%"));
+                Assert.Equal("prefix-secret123-suffix",
+                    OhmGraphite.CustomConfig.Expand("influx2_token", "prefix-%OHM_TEST_TOKEN%-suffix"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("OHM_TEST_TOKEN", null);
+            }
+        }
+
+        [Fact]
+        public void ExpandsDollarBraceEnvVars()
+        {
+            Environment.SetEnvironmentVariable("OHM_TEST_TOKEN", "secret123");
+            try
+            {
+                Assert.Equal("secret123", OhmGraphite.CustomConfig.Expand("influx2_token", "${OHM_TEST_TOKEN}"));
+                Assert.Equal("a-secret123-b",
+                    OhmGraphite.CustomConfig.Expand("influx2_token", "a-${OHM_TEST_TOKEN}-b"));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("OHM_TEST_TOKEN", null);
+            }
+        }
+
+        [Fact]
+        public void UnsetDollarBraceExpandsToEmpty()
+        {
+            Environment.SetEnvironmentVariable("OHM_TEST_UNSET", null);
+            Assert.Equal("", OhmGraphite.CustomConfig.Expand("influx2_token", "${OHM_TEST_UNSET}"));
+            Assert.Equal("a--b", OhmGraphite.CustomConfig.Expand("influx2_token", "a-${OHM_TEST_UNSET}-b"));
+        }
+
+        [Fact]
+        public void ExpandHandlesNullAndEmpty()
+        {
+            Assert.Null(OhmGraphite.CustomConfig.Expand("influx2_token", null));
+            Assert.Equal("", OhmGraphite.CustomConfig.Expand("influx2_token", ""));
+        }
+
+        [Fact]
+        public void ExpandLeavesPlainValuesUntouched()
+        {
+            Assert.Equal("localhost", OhmGraphite.CustomConfig.Expand("host", "localhost"));
+            Assert.Equal(
+                "http://example.com:8086/",
+                OhmGraphite.CustomConfig.Expand("influx_address", "http://example.com:8086/")
+            );
+        }
+
+        [Fact]
         public void CanInstallCertificateVerification()
         {
             var current = ServicePointManager.ServerCertificateValidationCallback;

--- a/OhmGraphite.Test/ConfigTest.cs
+++ b/OhmGraphite.Test/ConfigTest.cs
@@ -148,9 +148,9 @@ namespace OhmGraphite.Test
             Environment.SetEnvironmentVariable("OHM_TEST_TOKEN", "secret123");
             try
             {
-                Assert.Equal("secret123", OhmGraphite.CustomConfig.Expand("influx2_token", "%OHM_TEST_TOKEN%"));
+                Assert.Equal("secret123", OhmGraphite.CustomConfig.Expand("%OHM_TEST_TOKEN%"));
                 Assert.Equal("prefix-secret123-suffix",
-                    OhmGraphite.CustomConfig.Expand("influx2_token", "prefix-%OHM_TEST_TOKEN%-suffix"));
+                    OhmGraphite.CustomConfig.Expand("prefix-%OHM_TEST_TOKEN%-suffix"));
             }
             finally
             {
@@ -158,45 +158,27 @@ namespace OhmGraphite.Test
             }
         }
 
-        [Fact]
-        public void ExpandsDollarBraceEnvVars()
+        [Theory]
+        [InlineData("dont%change%me")]
+        [InlineData("ci834g%94fn%9cws*one_")]
+        public void UnsetPercentVarStaysLiteral(string happenstanceString)
         {
-            Environment.SetEnvironmentVariable("OHM_TEST_TOKEN", "secret123");
-            try
-            {
-                Assert.Equal("secret123", OhmGraphite.CustomConfig.Expand("influx2_token", "${OHM_TEST_TOKEN}"));
-                Assert.Equal("a-secret123-b",
-                    OhmGraphite.CustomConfig.Expand("influx2_token", "a-${OHM_TEST_TOKEN}-b"));
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("OHM_TEST_TOKEN", null);
-            }
-        }
-
-        [Fact]
-        public void UnsetDollarBraceExpandsToEmpty()
-        {
-            Environment.SetEnvironmentVariable("OHM_TEST_UNSET", null);
-            Assert.Equal("", OhmGraphite.CustomConfig.Expand("influx2_token", "${OHM_TEST_UNSET}"));
-            Assert.Equal("a--b", OhmGraphite.CustomConfig.Expand("influx2_token", "a-${OHM_TEST_UNSET}-b"));
+            Assert.Equal(happenstanceString, OhmGraphite.CustomConfig.Expand(happenstanceString));
         }
 
         [Fact]
         public void ExpandHandlesNullAndEmpty()
         {
-            Assert.Null(OhmGraphite.CustomConfig.Expand("influx2_token", null));
-            Assert.Equal("", OhmGraphite.CustomConfig.Expand("influx2_token", ""));
+            Assert.Null(OhmGraphite.CustomConfig.Expand(null));
+            Assert.Equal("", OhmGraphite.CustomConfig.Expand(""));
         }
 
-        [Fact]
-        public void ExpandLeavesPlainValuesUntouched()
+        [Theory]
+        [InlineData("localhost")]
+        [InlineData("https://example.com:8086/")]
+        public void ExpandLeavesPlainValuesUntouched(string plainValue)
         {
-            Assert.Equal("localhost", OhmGraphite.CustomConfig.Expand("host", "localhost"));
-            Assert.Equal(
-                "http://example.com:8086/",
-                OhmGraphite.CustomConfig.Expand("influx_address", "http://example.com:8086/")
-            );
+            Assert.Equal(plainValue, OhmGraphite.CustomConfig.Expand(plainValue));
         }
 
         [Fact]

--- a/OhmGraphite/CustomConfig.cs
+++ b/OhmGraphite/CustomConfig.cs
@@ -1,20 +1,10 @@
 using System;
 using System.Configuration;
-using System.Text.RegularExpressions;
-using NLog;
 
 namespace OhmGraphite
 {
     class CustomConfig : IAppConfig
     {
-        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-
-        // Matches ${NAME} where NAME is a typical env-var identifier. 
-        // %NAME% is handled separately by Environment.ExpandEnvironmentVariables.
-        private static readonly Regex DollarBraceVar = new Regex(
-            @"\$\{([A-Za-z_][A-Za-z0-9_]*)\}",
-            RegexOptions.Compiled);
-
         private readonly Configuration _config;
 
         public CustomConfig(Configuration config)
@@ -22,37 +12,10 @@ namespace OhmGraphite
             _config = config;
         }
 
-        public string this[string name] => Expand(name, _config.AppSettings.Settings[name]?.Value);
+        public string this[string name] => Expand(_config.AppSettings.Settings[name]?.Value);
         public string[] GetKeys() => _config.AppSettings.Settings.AllKeys;
 
-        internal static string Expand(string key, string value)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                return value;
-            }
-
-            // %VAR%: native Windows form. Unknown names are left literal by
-            // ExpandEnvironmentVariables, so we don't get warnings on those,
-            // but that's the documented Windows behavior and users get the
-            // literal back, which is easy to spot.
-            var expanded = Environment.ExpandEnvironmentVariables(value);
-
-            // ${VAR}: cross-shell/Docker form. 
-            // Unset variables resolve to an empty string and warn.
-            expanded = DollarBraceVar.Replace(expanded, match =>
-            {
-                var name = match.Groups[1].Value;
-                var resolved = Environment.GetEnvironmentVariable(name);
-                if (resolved == null)
-                {
-                    Logger.Warn("config key '{0}' references unset environment variable '{1}'; expanding to empty string", key, name);
-                    return string.Empty;
-                }
-                return resolved;
-            });
-
-            return expanded;
-        }
+        internal static string Expand(string value) =>
+            string.IsNullOrEmpty(value) ? value : Environment.ExpandEnvironmentVariables(value);
     }
 }

--- a/OhmGraphite/CustomConfig.cs
+++ b/OhmGraphite/CustomConfig.cs
@@ -1,9 +1,20 @@
-﻿using System.Configuration;
+using System;
+using System.Configuration;
+using System.Text.RegularExpressions;
+using NLog;
 
 namespace OhmGraphite
 {
     class CustomConfig : IAppConfig
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        // Matches ${NAME} where NAME is a typical env-var identifier. 
+        // %NAME% is handled separately by Environment.ExpandEnvironmentVariables.
+        private static readonly Regex DollarBraceVar = new Regex(
+            @"\$\{([A-Za-z_][A-Za-z0-9_]*)\}",
+            RegexOptions.Compiled);
+
         private readonly Configuration _config;
 
         public CustomConfig(Configuration config)
@@ -11,7 +22,37 @@ namespace OhmGraphite
             _config = config;
         }
 
-        public string this[string name] => _config.AppSettings.Settings[name]?.Value;
+        public string this[string name] => Expand(name, _config.AppSettings.Settings[name]?.Value);
         public string[] GetKeys() => _config.AppSettings.Settings.AllKeys;
+
+        internal static string Expand(string key, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            // %VAR%: native Windows form. Unknown names are left literal by
+            // ExpandEnvironmentVariables, so we don't get warnings on those,
+            // but that's the documented Windows behavior and users get the
+            // literal back, which is easy to spot.
+            var expanded = Environment.ExpandEnvironmentVariables(value);
+
+            // ${VAR}: cross-shell/Docker form. 
+            // Unset variables resolve to an empty string and warn.
+            expanded = DollarBraceVar.Replace(expanded, match =>
+            {
+                var name = match.Groups[1].Value;
+                var resolved = Environment.GetEnvironmentVariable(name);
+                if (resolved == null)
+                {
+                    Logger.Warn("config key '{0}' references unset environment variable '{1}'; expanding to empty string", key, name);
+                    return string.Empty;
+                }
+                return resolved;
+            });
+
+            return expanded;
+        }
     }
 }

--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="OhmGraphite.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="NLog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ App configuration is located in the installation directory at `OhmGraphite.exe.c
 
 Config updates require an app restart to take effect.
 
+Any `value` in the config can reference an environment variable so secrets (InfluxDB tokens, Postgres connection strings, etc.) don't have to live in the file. Both `%NAME%` and `${NAME}` are supported:
+
+```xml
+<add key="influx2_token" value="%INFLUX_TOKEN%" />
+<add key="timescale_connection" value="${TIMESCALE_CONN}" />
+```
+
+When running as a Windows service, set the variable machine-wide (e.g. via `setx /M INFLUX_TOKEN ...` or System Properties → Environment Variables) so the service account inherits it; per-user variables won't be visible to `LocalSystem`. Unset `${NAME}` references expand to an empty string and log a warning; unset `%NAME%` is left as the literal placeholder (Windows default).
+
 ### Graphite Configuration
 
 The config below polls our hardware every `5` seconds and sends the results to a graphite server listening on `localhost:2003`.

--- a/README.md
+++ b/README.md
@@ -56,14 +56,13 @@ App configuration is located in the installation directory at `OhmGraphite.exe.c
 
 Config updates require an app restart to take effect.
 
-Any `value` in the config can reference an environment variable so secrets (InfluxDB tokens, Postgres connection strings, etc.) don't have to live in the file. Both `%NAME%` and `${NAME}` are supported:
+Any `value` in the config can reference an environment variable using `%NAME%` so secrets (InfluxDB tokens, Postgres connection strings, etc.) don't have to live in the file:
 
 ```xml
 <add key="influx2_token" value="%INFLUX_TOKEN%" />
-<add key="timescale_connection" value="${TIMESCALE_CONN}" />
 ```
 
-When running as a Windows service, set the variable machine-wide (e.g. via `setx /M INFLUX_TOKEN ...` or System Properties → Environment Variables) so the service account inherits it; per-user variables won't be visible to `LocalSystem`. Unset `${NAME}` references expand to an empty string and log a warning; unset `%NAME%` is left as the literal placeholder (Windows default).
+When running as a Windows service, set the variable machine-wide (e.g. via `setx /M INFLUX_TOKEN ...` or System Properties → Environment Variables) so the service account inherits it; per-user variables won't be visible to `LocalSystem`. Unset references are left as the literal `%NAME%` placeholder (standard Windows behavior).
 
 ### Graphite Configuration
 


### PR DESCRIPTION
Lets any `value` in `OhmGraphite.exe.config` reference an environment variable, so the InfluxDB 2 token (and other secrets) does not have to live in the file on disk. 

Both `%NAME%` and `${NAME}` are supported, expansion happens once on read in `CustomConfig` so every backend benefits. 

Unset `${NAME}` resolves to empty and logs a warning; unset `%NAME%` stays literal (Windows default).

Includes unit tests for both syntaxes and the unset path, plus a short note in the README under `## Configuration`.
