### PR TITLE
Bump LibreHardwareMonitorLib to latest

### DIFF
--- a/OhmGraphite/OhmGraphite.csproj
+++ b/OhmGraphite/OhmGraphite.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.7-pre649" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.7-pre700" />
     <PackageReference Include="InfluxDB.Client" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.8" />

--- a/OhmGraphite/OhmNvme.cs
+++ b/OhmGraphite/OhmNvme.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
-using DiskInfoToolkit;
-using DiskInfoToolkit.Interop.Enums;
+﻿using System.Collections.Generic;
+using System.Linq;
+using DiskInfoToolkit.Smart;
 using LibreHardwareMonitor.Hardware;
 using LibreHardwareMonitor.Hardware.Storage;
 
@@ -59,18 +59,18 @@ namespace OhmGraphite
 
         public void Update()
         {
-            var smart = _nvme?.Storage?.Smart;
-            ErrorInfoLogEntryCount.Value = SmartValue(smart, SmartAttributeType.NumberOfErrorInformationLogEntries);
-            MediaErrors.Value = SmartValue(smart, SmartAttributeType.MediaAndDataIntegrityErrors);
-            PowerCycles.Value = SmartValue(smart, SmartAttributeType.PowerCycleCount);
-            UnsafeShutdowns.Value = SmartValue(smart, SmartAttributeType.UnsafeShutdownCount);
+            var attributes = _nvme?.Storage?.SmartAttributes;
+            ErrorInfoLogEntryCount.Value = SmartValue(attributes, SmartTextKeys.NumberOfErrorInformationLogEntries);
+            MediaErrors.Value = SmartValue(attributes, SmartTextKeys.MediaAndDataIntegrityErrors);
+            PowerCycles.Value = SmartValue(attributes, SmartTextKeys.PowerCycleCount);
+            UnsafeShutdowns.Value = SmartValue(attributes, SmartTextKeys.UnsafeShutdownCount);
         }
 
-        private static float? SmartValue(SmartInfo smart, SmartAttributeType type)
+        private static float? SmartValue(IEnumerable<DiskInfoToolkit.SmartAttributeEntry> attributes, string textKey)
         {
-            return smart?.SmartAttributes
-                ?.FirstOrDefault(attribute => attribute.Info.Type == type)
-                ?.Attribute.RawValueULong;
+            return attributes
+                ?.FirstOrDefault(attribute => attribute.TextKey == textKey)
+                ?.RawValue;
         }
     }
 }

--- a/OhmGraphite/SensorCollector.cs
+++ b/OhmGraphite/SensorCollector.cs
@@ -85,7 +85,7 @@ namespace OhmGraphite
                 SensorAdded(sensor);
             }
 
-            if (hardware is StorageDevice nvme && nvme.Storage.IsNVMe)
+            if (hardware is StorageDevice nvme && nvme.Storage.TransportKind == DiskInfoToolkit.StorageTransportKind.Nvme)
             {
                 var ohmNvme = new OhmNvme(nvme);
                 _nvmes.TryAdd(hardware.Identifier, ohmNvme);


### PR DESCRIPTION
From pre649 (273b47b) to pre700 (95e97cf)

- Added support for Intel Panther Lake and Arrow Lake-U CPUs (including a Panther Lake voltage fix).
- Corrected temperature offset calculations for newer Zen (Ryzen) processors.
- Added motherboard support for MSI B860 (NCT6687D-R) and ASRock B550M Pro4.
- Added sensor support for older Intel Framework laptops.
- NVIDIA GPUs now recover gracefully when the GPU driver restarts.
- NVIDIA GPU load index 3 is now reserved for GPU Memory and the remaining GPU loads have been remapped, so NVIDIA GPU load sensor names/order may change. Closes https://github.com/nickbabcock/OhmGraphite/issues/575
- Fixed NVMe temperature sensors and improved storage and SMART detection (storage backend upgraded to DiskInfoToolkit 2.x).
- Fixed long delays when reporting mechanical (HDD) read/write speeds.
- Fixed crashes from an X570 null reference and from an unhandled network interface exception during sensor updates.
- Fixed a potential freeze and added support for newer device firmware.