### PR TITLE
Fail with exit code 1 on startup errors

### DIFF
--- a/OhmGraphite/OhmCli.cs
+++ b/OhmGraphite/OhmCli.cs
@@ -155,14 +155,33 @@ namespace OhmGraphite
                         services.AddHostedService<Worker>();
                     });
 
-                builder.Build().Run();
+                try
+                {
+                    builder.Build().Run();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Fatal(ex, "OhmGraphite terminated due to startup failure");
+                    Environment.ExitCode = 1;
+                }
             }
             else
             {
-                var token = cancellationToken;
                 var worker = new Worker(config);
-                await worker.StartAsync(token);
-                await worker.ExecuteTask;
+                try
+                {
+                    await worker.StartAsync(cancellationToken);
+                    await worker.ExecuteTask;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Fatal(ex, "OhmGraphite terminated due to startup failure");
+                    Environment.ExitCode = 1;
+                }
+                finally
+                {
+                    worker.Dispose();
+                }
             }
         }
 

--- a/OhmGraphite/Worker.cs
+++ b/OhmGraphite/Worker.cs
@@ -1,4 +1,5 @@
-﻿using NLog;
+﻿using System;
+using NLog;
 using LibreHardwareMonitor.Hardware;
 using Prometheus;
 using System.Threading.Tasks;
@@ -12,19 +13,36 @@ namespace OhmGraphite
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         private readonly MetricConfig config;
+        private IManage _app;
+
         public Worker(MetricConfig config)
         {
             this.config = config;
         }
 
-        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        public override async Task StartAsync(CancellationToken cancellationToken)
         {
-            return Task.Run(() =>
+            _app = CreateOhmGraphite(config);
+            _app.Start();
+            await base.StartAsync(cancellationToken);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // Simply keep the service alive until shutdown is requested.
+            try
             {
-                using var app = CreateOhmGraphite(config);
-                app.Start();
-                stoppingToken.WaitHandle.WaitOne();
-            }, stoppingToken);
+                await Task.Delay(Timeout.Infinite, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        public override void Dispose()
+        {
+            _app?.Dispose();
+            base.Dispose();
         }
 
         private static IManage CreateOhmGraphite(MetricConfig config)


### PR DESCRIPTION
Init in StartAsync instead of ExecuteAsync so that exceptions propagate to the htos.